### PR TITLE
Lucee 

### DIFF
--- a/Installation.txt
+++ b/Installation.txt
@@ -1,7 +1,7 @@
 REQUIREMENTS
-- Must have ColdFusion, Railo or OpenBD installed
+- Must have ColdFusion, Lucee, Railo or OpenBD installed
 - Access to a MySQL 4+, PostgreSQL 8+, Microsoft SQL 2000+ or Oracle 10g+ database server and the ability to add a new database
-- Ability to add a Datasource to ColdFusion, Railo or OpenBD Administrator
+- Ability to add a Datasource to ColdFusion, Lucee, Railo or OpenBD Administrator
 
 INSTALLATION
 1. Put the contents of your Mura Standard download into your webroot (the directory where your site will live). This includes the following directories and files: admin, config, default, plugins, requirements, tasks, Application.cfc, contentServer.cfm, index.cfm, MuraProxy.cfm.

--- a/admin/common/layouts/includes/header.cfm
+++ b/admin/common/layouts/includes/header.cfm
@@ -113,7 +113,8 @@
 																<strong>#rc.$.rbKey('version.appserver')#</strong>
 																#listFirst(server.coldfusion.productname,' ')#
 																<cfif structKeyExists(server,'railo') and structKeyExists(server.railo,'version') >(#server.railo.version#)
-																<cfelseif structKeyExists(server,'luccee') and structKeyExists(server.railo,'version') >(#server.railo.version#)<cfelseif structKeyExists(server,'coldfusion') and structKeyExists(server.coldfusion,'productversion') >(#server.coldfusion.productversion#)</cfif>
+																<cfelseif structKeyExists(server,'lucee') and structKeyExists(server.railo,'version') >(#server.railo.version#)
+																<cfelseif structKeyExists(server,'coldfusion') and structKeyExists(server.coldfusion,'productversion') >(#server.coldfusion.productversion#)</cfif>
 															</a>
 														</li>
 														<cfif rc.$.globalConfig('javaEnabled')>


### PR DESCRIPTION
Noticed Lucee was added to header.cfm version, but misspelled.
Note: should we also be changing server.railo,'version' to server.lucee,'version' ( or does Lucee still report the server config values as "railo" ) ?
