### PR TITLE
Adding esapiEncode calls to several GET params

### DIFF
--- a/admin/core/views/cextend/editrelatedcontentset.cfm
+++ b/admin/core/views/cextend/editrelatedcontentset.cfm
@@ -105,7 +105,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfelse>
 	<input type="button" class="btn" onclick="submitForm(document.forms.form1,'delete','Delete Related Content Set?');" value="Delete" />
 	<input type="button" class="btn" onclick="submitForm(document.forms.form1,'update');" value="Update" />
-	<input type=hidden name="relatedContentSetID" value="#rcsBean.getRelatedContentSetID()#">
+	<input type=hidden name="relatedContentSetID" value="#esapiEncode('html_attr',rcsBean.getRelatedContentSetID())#">
 </cfif>
 </div>
 

--- a/admin/core/views/cextend/editset.cfm
+++ b/admin/core/views/cextend/editset.cfm
@@ -123,14 +123,14 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfelse>
 	<input type="button" class="btn" onclick="submitForm(document.forms.form1,'delete','Delete Attribute Set?');" value="Delete" />
 	<input type="button" class="btn" onclick="submitForm(document.forms.form1,'update');" value="Update" />
-	<input type=hidden name="extendSetID" value="#extendSetBean.getExtendSetID()#">
+	<input type=hidden name="extendSetID" value="#esapiEncode('html_attr',extendSetBean.getExtendSetID())#">
 </cfif>
 </div>
 
 <input type="hidden" name="action" value="">
 <input name="muraAction" value="cExtend.updateSet" type="hidden">
 <input name="siteID" value="#esapiEncode('html_attr',rc.siteid)#" type="hidden">
-<input name="subTypeID" value="#subType.getSubTypeID()#" type="hidden">
+<input name="subTypeID" value="#esapiEncode('html_attr',subType.getSubTypeID())#" type="hidden">
 #rc.$.renderCSRFTokens(context=rc.extendSetID,format="form")#
 </form>
 </cfoutput>

--- a/admin/core/views/cextend/editsubtype.cfm
+++ b/admin/core/views/cextend/editsubtype.cfm
@@ -203,7 +203,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	<cfelse>
 		<input type="button" class="btn" onclick="submitForm(document.forms.subTypeFrm,'delete','Delete Class Extension?');" value="Delete" />
 		<input type="button" class="btn" onclick="submitForm(document.forms.subTypeFrm,'update');" value="Update" />
-		<input type=hidden name="subTypeID" value="#subType.getsubtypeID()#">
+		<input type=hidden name="subTypeID" value="#esapiEncode('html_attr',subType.getsubtypeID())#">
 	</cfif>
 </div>
 

--- a/admin/core/views/cmailinglist/listmembers.cfm
+++ b/admin/core/views/cmailinglist/listmembers.cfm
@@ -102,7 +102,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <div class="form-actions">
 <input type="button" class="btn" onclick="submitForm(document.forms.form1);" value="#application.rbFactory.getKeyValue(session.rb,'mailinglistmanager.submit')#" />
 </div>
-<input type=hidden name="mlid" value="#rc.mlid#">
+<input type=hidden name="mlid" value="#esapiEncode('html_attr',rc.mlid)#">
 <input type=hidden name="siteid" value="#esapiEncode('html_attr',rc.siteid)#">
 <input type=hidden name="isVerified" value="1">
 </form>


### PR DESCRIPTION
While setting up a 'Dockerised' install of Mura, I came across a few possible XSS vectors. The below commit should resolve these, by using the 'esapiEncode' function, as has been done in other parts of the Mura source.