### PR TITLE
Possible fix for and/or groupings in muraORM beans

### DIFF
--- a/requirements/mura/bean/beanFeed.cfc
+++ b/requirements/mura/bean/beanFeed.cfc
@@ -454,9 +454,15 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 				<cfset started = true />
 
 				<cfset isListParam=listFindNoCase("IN,NOT IN",param.getCondition())>					
-				#param.getFieldStatement()# #param.getCondition()# <cfif isListParam>(</cfif><cfqueryparam cfsqltype="cf_sql_#param.getDataType()#" value="#param.getCriteria()#" list="#iif(isListParam,de('true'),de('false'))#" null="#iif(param.getCriteria() eq 'null',de('true'),de('false'))#"><cfif isListParam>)</cfif>  	
-				
-				<cfset openGrouping=false />
+				<cfif len(param.getField())>
+					#param.getFieldStatement()# 
+					<cfif param.getCriteria() eq 'null'>
+						IS NULL
+					<cfelse>
+						#param.getCondition()# <cfif isListParam>(</cfif><cfqueryparam cfsqltype="cf_sql_#param.getDataType()#" value="#param.getCriteria()#" list="#iif(isListParam,de('true'),de('false'))#" null="#iif(param.getCriteria() eq 'null',de('true'),de('false'))#"><cfif isListParam>)</cfif>  	
+					</cfif>
+					<cfset openGrouping=false />
+				</cfif>
 			</cfif>						
 		</cfloop>
 		<cfif started>)</cfif>


### PR DESCRIPTION
I'm not sure if this is a complete solution, but I hit a snag trying to use and/or groupings in MuraORM feed beans. The exact same syntax worked fine on a userFeedBean (and on contentFeedBeans) but not on the muraORM ones. This change got me running again and I thought I'd post it up as a pull request in case others have encountered it. Here's a sample syntax I was trying to get working:

		fb.addParam(
			field = "histStart",
			criteria = now(),
			condition = "lte",
			relationship = "and"
		)
		.addParam(relationship='andOpenGrouping')
			.addParam(
				field = "histEnd",
				criteria = "null",
				condition = "eq"
			)
			.addParam(
				field = "histEnd",
				criteria = now(),
				condition = "gte",
				relationship = "or"
			)
		.addParam(relationship='closeGrouping');

After some digging, the resulting query looked like it was putting out empty parameters or the "and" or "or" keyword in the wrong places. Adding the condition (which I saw in the userFeedBean) and the test for null (which i saw in feedGateway) got me running again on the 6.1 codebase.

Thanks!