### PR TITLE
Tweak to retain seconds in params

### DIFF
--- a/requirements/mura/queryParam.cfc
+++ b/requirements/mura/queryParam.cfc
@@ -227,13 +227,13 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 					<cfset tmp=lsParseDateTime(tmp)>
 					<cfcatch><!--- already parsed ---></cfcatch>
 				</cftry>
-				<cfset variables.criteria=createODBCDateTime(createDateTime(year(tmp),month(tmp),day(tmp),hour(tmp),minute(tmp),0)) />
+				<cfset variables.criteria=createODBCDateTime(tmp) />
 			<cfelseif isDate(tmp)>
 				<cftry>
 					<cfset tmp=parseDateTime(tmp)>
 					<cfcatch><!--- already parsed ---></cfcatch>
 				</cftry>
-				<cfset variables.criteria=createODBCDateTime(createDateTime(year(tmp),month(tmp),day(tmp),hour(tmp),minute(tmp),0)) />
+				<cfset variables.criteria=createODBCDateTime(tmp) />
 			<cfelse>
 				<cfset variables.criteria="" />
 				<cfset setIsValid(false) />


### PR DESCRIPTION
I emailed you about this earlier but figured i'd try the optimistic approach and do a pull request that fixes my issue.

I don't know if you were stripping the seconds off for a reason but i need to retain them in my project and hopefully this change is okay to do that.