### PR TITLE
 Fix: ReferenceError: timedMousePos is not defined

### DIFF
--- a/requirements/cfformprotect/js/cffp.js
+++ b/requirements/cfformprotect/js/cffp.js
@@ -46,7 +46,7 @@ if(!window.CFFormProtect){
 	}
 
 	// capture mouse movement
-	function timedMousePos() {
+	var timedMousePos =  function() {
 		//when the user moves the mouse, start working
 		document.onmousemove = getMousePos;
 		if (xPos >= 0 && yPos >= 0) {
@@ -92,7 +92,7 @@ if(!window.CFFormProtect){
 	//capture when a user uses types on their keyboard
 	document.onkeypress = logKeys;
 
-	function logKeys() {
+	var logKeys = function() {
 		//user hit a key, increment the counter
 		keysPressed++;
 		// Bas van der Graaf (bvdgraaf@e-dynamics.nl) 


### PR DESCRIPTION
Fix for `ReferenceError: timedMousePos is not defined` error. eighter the fix is to define the function in variables or to reorder the logKeys-Function, before the documnet.onkeypress / timedMousePos before setTimeout