### PR TITLE
Make comment remoteID consistent with tcontent

### DIFF
--- a/requirements/mura/dbUpdates/6.2.cfm
+++ b/requirements/mura/dbUpdates/6.2.cfm
@@ -13,6 +13,9 @@
 
 dbUtility.setTable('tcontentrelated')
 		.alterColumn(column='relatedContentSetID',dataType='varchar',length='35',default='00000000000000000000000000000000000');
+
+dbUtility.setTable('tcontentcomments')
+		.alterColumn(column='remoteID',dataType='varchar',length='255',default='');
 </cfscript>
 
 <cfquery>


### PR DESCRIPTION
I've been working on a project that uses remoteID on tcontentcomments but ran into a field length limit (35) - and saw that tcontent has remoteid set as varchar 255 and thought it'd be good to make it consistent. It'd certainly help my project!