### PR TITLE
fix for data.getSiteID() being referenced instead of params.getSiteID() ...

### DIFF
--- a/requirements/mura/user/userGateway.cfc
+++ b/requirements/mura/user/userGateway.cfc
@@ -312,7 +312,7 @@
 							</cfif>
 							and 
 							<cfif param.getCondition() neq "like">
-								<cfset castfield=variables.configBean.getClassExtensionManager().getCastString(param.getField(),data.getsiteid())>
+								<cfset castfield=variables.configBean.getClassExtensionManager().getCastString(param.getField(),params.getsiteid())>
 							</cfif> 
 							<cfif param.getCondition() eq "like" and variables.configBean.getDbCaseSensitive()>
 								upper(#castfield#)


### PR DESCRIPTION
arguments.data within UserGateway.getAdvancedSearch() accepts an argument of **data** which can be a userFeedBean or a struct

If a struct is passed in then params is set to a new userFeedBeen initialised with the struct - otherwise params is set to the object passed in.

On line 315 data.getSiteID() is called directly - which does not work if arguments.data is a structure - should instead be referencing params.data