### PR TITLE
Fix issue for dynamic environment

### DIFF
--- a/config/applicationSettings.cfm
+++ b/config/applicationSettings.cfm
@@ -227,7 +227,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfset this.ormSettings.cfclocation=[]>
 
 <cftry>
-	<cfinclude template="#variables.context#/config/cfapplication.cfm">
+	<cfinclude template="cfapplication.cfm">
 	<cfset request.hasCFApplicationCFM=true>
 	<cfcatch>
 		<cfset request.hasCFApplicationCFM=false>


### PR DESCRIPTION
we use cfapplication.cfm to dynamically set the environment (datasource, context and so on), but this is impossible if using a context. because of the line 230 the file is not found, if the context is wrong, in our opinion the include would have the same effect without the context-variable, because the file is in the same folder. is it possible to remove that variable?