### PR TITLE
Fix SOAP API call to Read User by UserID

### DIFF
--- a/requirements/mura/client/api/soap/v1/user.cfc
+++ b/requirements/mura/client/api/soap/v1/user.cfc
@@ -62,7 +62,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	<cfset var user="">
 	
 	<cfif len(event.getValue("userID"))>
-		<cfset user=application.userManager.read(event.getValue("userID"),event.getValue("siteid"))>
+		<cfset user=application.userManager.read(userid=event.getValue("userID"),siteID=event.getValue("siteid"))>
 	<cfelseif len(event.getValue("groupname"))>
 		<cfset user=application.userManager.readByGroupName(event.getValue("groupname"),event.getValue("siteid"))>
 	<cfelseif len(event.getValue("username"))>


### PR DESCRIPTION
Existing calls to mura.client.api.soap.v1.user.getBean() to retrieve userDetails via UserID will fail, due to call to userManager.read() passing userID and siteID as ordered arguments - which were then parsed as userID and userName arguments.

It appears that this functionality has been broken for several years - possibly for ever...

Prior to changes in commit https://github.com/blueriver/MuraCMS/commit/013f397c4d00f01174462197af001757d79a2196#diff-841791696abe9220f28410628dc4f7caR106 in May 2012 these calls did *work* as username argument would not be checked if siteID not defined.  This commit set the siteID if defined within the session, which then caused the existing functionality to check the userName argument... which as it is being set to the siteID in the call from mura.client.api.soap.v1.user.getBean()... would never retrieve the correct user (which also causes the other related user functions to fail when called through the SOAP API).


This pull request fixes the issue by switching call to userManager.read within mura.client.api.soap.v1.user.getBean() to use named arguments for userID and siteID.

(please note... I have a signed contribution agreement ready to send over if required, if someone can tell me where to send it!)

Cheers,

Dan.