### PR TITLE
Allow passing metaImageSizeArgs to dspBody in defaultCase

### DIFF
--- a/requirements/mura/content/contentRenderer.cfc
+++ b/requirements/mura/content/contentRenderer.cfc
@@ -2358,7 +2358,7 @@ Display Objects
 									<a href="#variables.$.content().getImageURL(size='large')#" title="#HTMLEditFormat(variables.event.getValue('contentBean').getMenuTitle())#" #this.shadowboxattribute#="shadowbox[body]" id="svAsset" class="mura-asset"><img src="#variables.$.content().getImageURL(argumentCollection=arguments.metaImageSizeArgs)#" class="imgMed #arguments.metaImageClass#" alt="#HTMLEditFormat(variables.event.getValue('contentBean').getMenuTitle())#" /></a>
 									<cfelse>
 									<div id="svAsset" class="mura-asset">
-									<img src="#variables.$.content().getImageURL(size='medium')#" class="imgMed #arguments.metaImageClass#" alt="#HTMLEditFormat(variables.event.getValue('contentBean').getMenuTitle())#" />
+									<img src="#variables.$.content().getImageURL(argumentCollection=arguments.metaImageSizeArgs)#" class="imgMed #arguments.metaImageClass#" alt="#HTMLEditFormat(variables.event.getValue('contentBean').getMenuTitle())#" />
 									</div>
 								</cfif>
 								</cfoutput>	


### PR DESCRIPTION
metaImageSizeArgs passed to dspBody are ignored if includeMetaHREF is
false in the defaultcase in the contentRender.cfc. Fix for issue 1913