### PR TITLE
Update resourceBundle.cfc

### DIFF
--- a/requirements/mura/resourceBundle/resourceBundle.cfc
+++ b/requirements/mura/resourceBundle/resourceBundle.cfc
@@ -92,7 +92,7 @@
 		var thisMSG="";
 		var fis=createObject("java", "java.io.FileInputStream").init(arguments.rbFile);
 		var rB=createObject("java", "java.util.PropertyResourceBundle").init(fis);
-		var keys=variables.rB.getKeys();
+		var keys=rB.getKeys();
 
 		while (keys.hasMoreElements()) {
 			thisKEY=keys.nextElement();


### PR DESCRIPTION
This variables-scoped reference for rB was suddenly causing some hard errors. Removing the keyword here sorted everything out. 

Component [mura.resourceBundle.resourceBundle] has no accessible Member with name [rB]