### PR TITLE
Update web.config.txt

### DIFF
--- a/web.config.txt
+++ b/web.config.txt
@@ -100,7 +100,9 @@
 
 		<staticContent>
 			<remove fileExtension=".woff" />
-			<mimeMap fileExtension=".woff" mimeType="application/octet-stream" />
+			<remove fileExtension=".woff2" />
+			<mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+			<mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
 		</staticContent>
 
 	</system.webServer>

--- a/web.config.txt
+++ b/web.config.txt
@@ -101,7 +101,7 @@
 		<staticContent>
 			<remove fileExtension=".woff" />
 			<remove fileExtension=".woff2" />
-			<mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+			<mimeMap fileExtension=".woff" mimeType="application/font-woff" />
 			<mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
 		</staticContent>
 


### PR DESCRIPTION
Added a MIME map declaration for the .woff2 file extension and updated the MIME type for the .woff file extension.  There is no MIME type defined by default for the .woff2 file extension using IIS 8.5 on Windows 2012 R2 servers.