### PR TITLE
Update filetools.cfm

### DIFF
--- a/requirements/mura/customtags/filetools.cfm
+++ b/requirements/mura/customtags/filetools.cfm
@@ -56,7 +56,7 @@
 	</cfif>
 	<cfif fileMetaData.hasImageFileExt()>
 		</div>
-		<img id="assocImage" src="#request.context.$.getURLForImage(fileid=attributes.bean.getvalue(attributes.property),size=attributes.size)#?cacheID=#createUUID()#" />
+		<img id="assocImage" src="#request.context.$.getURLForImage(fileid=attributes.bean.getvalue(attributes.property),size=attributes.size,siteid=attributes.bean.getSiteId())#?cacheID=#createUUID()#" />
 	</cfif>	
 
 	<cfif not (attributes.bean.getType() eq 'File' and attributes.property eq 'fileid')>


### PR DESCRIPTION
Fixes issue where image for bean isn't loaded properly when displayed in the context of an alternate siteid.