### PR TITLE
Configurable BCC on forgotPassword

### DIFF
--- a/requirements/mura/user/userUtility.cfc
+++ b/requirements/mura/user/userUtility.cfc
@@ -400,7 +400,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 									<cfset arguments.subject='#struser.from# Account Information'>
 								</cfif>
 								
-								<cfset sendLogin(struser,'#arguments.email#','#struser.from#',arguments.subject,'#arguments.siteid#','','',arguments.message)>
+								<cfset sendLogin(struser,'#arguments.email#','#struser.from#',arguments.subject,'#arguments.siteid#','',variables.configBean.getValue("sendLoginBcc"),arguments.message)>
 								<cfset msg="Your account information has been sent to you.">
 							</cfif>
 						</cfloop>


### PR DESCRIPTION
We have a client who would like to have all forgotPassword requests BCC'd to their IT team. Would this be a possible addition we can get into the core to keep them on the upgrade path? If there's a better way, I'm open to that, too!

Thanks!