### PR TITLE
Fixes mapping / getMetaData() bug

### DIFF
--- a/requirements/mura/plugin/pluginStandardEventWrapper.cfc
+++ b/requirements/mura/plugin/pluginStandardEventWrapper.cfc
@@ -65,7 +65,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfargument name="context">
 	<cfset var contexts=structNew()>
 	
-	<cfif getMetaData(arguments.context).name eq "mura.MuraScope">
+	<cfif listLast(getMetaData(arguments.context).name, '.') eq "MuraScope">
 		<cfset contexts.muraScope=arguments.context>
 		<cfset contexts.event=arguments.context.event()>
 	<cfelse>


### PR DESCRIPTION
This fixes an issue with how component names are rendered in different environments.  It is in reference to this google group thread.

https://groups.google.com/d/msg/mura-cms-developers/fEc0-CZsybg/iHLpoql1BwAJ