### PR TITLE
Fix for null javax path info

### DIFF
--- a/requirements/mura/bean/bean.cfc
+++ b/requirements/mura/bean/bean.cfc
@@ -260,7 +260,7 @@ component extends="mura.cfobject" output="false" {
 			variables.instance.isNew=0;
 		} else if(isStruct(arguments.data)){
 			for(prop in arguments.data){
-				if ( IsSimpleValue(prop) && Len(prop) && !(prop==getPrimaryKey() && !len(arguments.data['#prop#'])) ) {
+				if ( IsSimpleValue(prop) && !isNull(arguments.data[prop]) && Len(prop) && !(prop==getPrimaryKey() && !len(arguments.data['#prop#'])) ) {
 					setValue(prop,arguments.data['#prop#']);
 				}
 			}		


### PR DESCRIPTION
When submitting a mailing list signup form on Lucee 4.5.2, the struct key for "javax.servlet.forward.path_info" may be cast as a null, depending on the server configuration (e.g. - CommandBox embedded server).  

This results in the error "the value from key [javax.servlet.forward.path_info] is NULL"    This ensures that the loop does not error out because of the missing path_info variable.