### PR TITLE
Remove duplicate code

### DIFF
--- a/default/includes/display_objects/htmlhead/global.cfm
+++ b/default/includes/display_objects/htmlhead/global.cfm
@@ -52,7 +52,6 @@ initMura({
 	contentid:"#variables.$.content('contentid')#",
 	contenthistid:"#variables.$.content('contenthistid')#",
 	parentid:"#variables.$.content('parentid')#",
-	siteID:"#variables.$.event('siteID')#",
 	context:"#variables.$.globalConfig('context')#",
 	nocache:#val($.event('nocache'))#,
 	assetpath:"#variables.$.siteConfig('assetPath')#",


### PR DESCRIPTION
The argument `siteid` is being defined twice in this call to the initMura function. Once in all lowercase `siteid` and again in camel case `siteID`. I searched within the global.js and global.min.js files and there are no references to the camel case variable. So it does not appear to be needed here.