### PR TITLE
We need to be able to set session cookies that expire on session (browser close).

### DIFF
--- a/requirements/mura/utility.cfc
+++ b/requirements/mura/utility.cfc
@@ -493,77 +493,23 @@ Blog: www.codfusion.com--->
 <cffunction name="setSessionCookies">
 	<cftry>
 		<cfif isdefined('session.CFID')>
-			<cfif server.coldfusion.productname neq 'Coldfusion Server'>
-				<cfset setCookie('cfid', session.CFID, application.configBean.getSessionCookiesExpires(), "", "/", application.configBean.getSecureCookies(), true, true)>
-				<cfset setCookie('cftoken', session.CFTOKEN, application.configBean.getSessionCookiesExpires(), "", "/", application.configBean.getSecureCookies(), true, true)>
+			<cfif application.configBean.getSessionCookiesExpires EQ "" OR application.configBean.getSessionCookiesExpires EQ "session">
+				<cfcookie name="CFID" value="#session.CFID#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 			<cfelse>
 				<cfcookie name="CFID" value="#session.CFID#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 			</cfif>
 		</cfif>
 		<cfif isdefined('session.jsessionid')>
-			<cfcookie name="JSESSIONID" value="#session.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+			<cfif application.configBean.getSessionCookiesExpires EQ "" OR application.configBean.getSessionCookiesExpires EQ "session">
+				<cfcookie name="JSESSIONID" value="#session.jsessionid#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+			<cfelse>
+				<cfcookie name="JSESSIONID" value="#session.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+			</cfif>
 		</cfif>
 	<cfcatch></cfcatch>
 	</cftry>
-</cffunction>
-
-<!---
-Blog:http://www.modernsignal.com/coldfusionhttponlycookie--->
-<cffunction name="SetCookie" hint="Replacement for cfcookie that handles httponly cookies" output="false" returntype="void">
-    <cfargument name="name" type="string" required="true">
-    <cfargument name="value" type="string" required="true">
-    <cfargument name="expires" type="any" default="" hint="''=session only|now|never|[date]|[number of days]">
-    <cfargument name="domain" type="string" default="">
-    <cfargument name="path" type="string" default="/">
-    <cfargument name="secure" type="boolean" default="false">
-    <cfargument name="httponly" type="boolean" default="false">
-    <cfargument name="maintainCase" type="boolean" default="false">
-    <cfset var c = "">
-    <cfset var expDate = "">
-
-	<cfif arguments.maintainCase>
-		<cfset c = "#name#=#value#;">
-	<cfelseif server.coldfusion.productname eq "BlueDragon">
-		<cfset c = "#LCase(name)#=#value#;">
-	<cfelse>
-		<cfset c = "#UCase(name)#=#value#;">
-	</cfif>
-
-    <cfswitch expression="#Arguments.expires#">
-        <cfcase value="">
-        </cfcase>
-        <cfcase value="now">
-            <cfset expDate = DateAdd('d',-1,Now())>
-        </cfcase>
-        <cfcase value="never">
-            <cfset expDate = DateAdd('yyyy',30,Now())>
-        </cfcase>
-        <cfdefaultcase>
-            <cfif IsDate(Arguments.expires)>
-                <cfset expDate = Arguments.expires>
-            <cfelseif IsNumeric(Arguments.expires)>
-                <cfset expDate = DateAdd('d',Arguments.expires,Now())>
-            </cfif>
-        </cfdefaultcase>
-    </cfswitch>
-    <cfif IsDate(expDate) gt 0>
-        <cfset expDate = DateConvert('local2Utc',expDate)>
-        <cfset c = c & "expires=#DateFormat(expDate, 'ddd, dd-mmm-yyyy')# #TimeFormat(expDate, 'HH:mm:ss')# GMT;">
-    </cfif>
-    <cfif Len(Arguments.domain) gt 0>
-        <cfset c = c & "domain=#Arguments.domain#;">
-    </cfif>
-    <cfif Len(Arguments.path) gt 0>
-        <cfset c = c & "path=#Arguments.path#;">
-    </cfif>
-    <cfif Arguments.secure>
-        <cfset c = c & "secure;">
-    </cfif>
-    <cfif Arguments.httponly>
-        <cfset c = c & "httponly;">
-    </cfif>
-    <cfheader name="Set-Cookie" value="#c#" />
 </cffunction>
 
 <cffunction name="fixQueryPaths" output="false">

--- a/requirements/mura/utility.cfc
+++ b/requirements/mura/utility.cfc
@@ -493,7 +493,7 @@ Blog: www.codfusion.com--->
 <cffunction name="setSessionCookies">
 	<cftry>
 		<cfif isdefined('session.CFID')>
-			<cfif application.configBean.getSessionCookiesExpires EQ "" OR application.configBean.getSessionCookiesExpires EQ "session">
+			<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
 				<cfcookie name="CFID" value="#session.CFID#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 			<cfelse>
@@ -502,7 +502,7 @@ Blog: www.codfusion.com--->
 			</cfif>
 		</cfif>
 		<cfif isdefined('session.jsessionid')>
-			<cfif application.configBean.getSessionCookiesExpires EQ "" OR application.configBean.getSessionCookiesExpires EQ "session">
+			<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
 				<cfcookie name="JSESSIONID" value="#session.jsessionid#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 			<cfelse>
 				<cfcookie name="JSESSIONID" value="#session.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>


### PR DESCRIPTION
So that when the user closes the browser he or she is logged out.

As this can only be done by *not* providing the expires="..." attribute to cfcookie, we need an extra cfif statement.

And we don't need the setCookie function anymore as all modern CFML engines support secure and httpOnly.