### PR TITLE
Issue #2057

### DIFF
--- a/requirements/mura/user/sessionUserFacade.cfc
+++ b/requirements/mura/user/sessionUserFacade.cfc
@@ -203,7 +203,7 @@
 		<cfreturn false>
 	</cfif>
 
-	<cfif arguments.$.event('csrf_token_expires') gt (now() + 0) and arguments.$.event('csrf_token') eq hash(arguments.context & session.mura.csrfsecretkey & arguments.$.event('csrf_token_expires'))>
+	<cfif arguments.$.event('csrf_token_expires') gt datetimeformat(now(),'yyMMddHHnnsslll') and arguments.$.event('csrf_token') eq hash(arguments.context & session.mura.csrfsecretkey & arguments.$.event('csrf_token_expires'))>
 		<cfset session.mura.csrfusedtokens["#arguments.$.event('csrf_token')#"]=now()>
 		<cfreturn true>
 	<cfelse>
@@ -214,7 +214,10 @@
 <cffunction name="generateCSRFTokens" output="false">
 	<cfargument name="timespan" default="#createTimeSpan(0,3,0,0)#">
 	<cfargument name="context" default="">
-	<cfset var expires="#numberFormat((now() + arguments.timespan),'99999.9999999')#">
+
+	<cfset var currentDateTime = now()>
+	<cfset var milliseconds = datetimeFormat(currentDateTime,'lll')/>
+	<cfset var expires=dateTimeFormat(dateAdd('l',milliseconds,(currentDateTime + arguments.timespan)),'yyMMddHHnnsslll')>
 
 	<cfreturn {
 		expires=expires,


### PR DESCRIPTION
This is a little more complicated than it needs to be because the only way ACF provides to add 2 datetimes is by using the + operator. But doing so discards the milliseconds. So I have to use dateAdd() to re-add the milliseconds to our timestamp in order to have millisecond resolution on our timestamp. Also, a 2-digit year was used because a 4-digit year overflowed javascript's 64-bit integer which oddly enough only uses 53 bits.

I've tested this thoroughly on ACF11. But that is all. 