### PR TITLE
setClientCookies=true sets cookies as does utility.setSessionCookies().

### DIFF
--- a/config/applicationSettings.cfm
+++ b/config/applicationSettings.cfm
@@ -79,7 +79,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfset this.sessionManagement = true>
 
 <!--- We don't set client cookies here, because they are not set secure if required. We use setSessionCookies() --->
-<cfset this.setClientCookies = true>
+<cfset this.setClientCookies = false>
 
 <!--- should cookies be domain specific, ie, *.foo.com or www.foo.com
 <cfset this.setDomainCookies = not refind('\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b',listFirst(cgi.http_host,":"))>

--- a/requirements/mura/utility.cfc
+++ b/requirements/mura/utility.cfc
@@ -493,12 +493,23 @@ Blog: www.codfusion.com--->
 <cffunction name="setSessionCookies">
 	<cftry>
 		<cfif isdefined('session.CFID')>
-			<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
-				<cfcookie name="CFID" value="#session.CFID#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+			<!--- Lucee uses lowercase cookies the setCookie method allows it to maintain case--->
+			<cfif server.coldfusion.productname neq 'Coldfusion Server'>
+				<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
+					<cfset setCookie('cfid', session.CFID,"", "", "/", application.configBean.getSecureCookies(), true, true)>
+					<cfset setCookie('cftoken', session.CFTOKEN, "", "", "/", application.configBean.getSecureCookies(), true, true)>
+				<cfelse>
+					<cfset setCookie('cfid', session.CFID, application.configBean.getSessionCookiesExpires(), "", "/", application.configBean.getSecureCookies(), true, true)>
+					<cfset setCookie('cftoken', session.CFTOKEN, application.configBean.getSessionCookiesExpires(), "", "/", application.configBean.getSecureCookies(), true, true)>
+				</cfif>
 			<cfelse>
-				<cfcookie name="CFID" value="#session.CFID#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
+					<cfcookie name="CFID" value="#session.CFID#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+					<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				<cfelse>
+					<cfcookie name="CFID" value="#session.CFID#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+					<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				</cfif>
 			</cfif>
 		</cfif>
 		<cfif isdefined('session.jsessionid')>
@@ -510,6 +521,64 @@ Blog: www.codfusion.com--->
 		</cfif>
 	<cfcatch></cfcatch>
 	</cftry>
+</cffunction>
+
+<!---
+Blog:http://www.modernsignal.com/coldfusionhttponlycookie--->
+<cffunction name="SetCookie" hint="Replacement for cfcookie that handles httponly cookies" output="false" returntype="void">
+    <cfargument name="name" type="string" required="true">
+    <cfargument name="value" type="string" required="true">
+    <cfargument name="expires" type="any" default="" hint="''=session only|now|never|[date]|[number of days]">
+    <cfargument name="domain" type="string" default="">
+    <cfargument name="path" type="string" default="/">
+    <cfargument name="secure" type="boolean" default="false">
+    <cfargument name="httponly" type="boolean" default="false">
+    <cfargument name="maintainCase" type="boolean" default="false">
+    <cfset var c = "">
+    <cfset var expDate = "">
+
+	<cfif arguments.maintainCase>
+		<cfset c = "#name#=#value#;">
+	<cfelseif server.coldfusion.productname eq "BlueDragon">
+		<cfset c = "#LCase(name)#=#value#;">
+	<cfelse>
+		<cfset c = "#UCase(name)#=#value#;">
+	</cfif>
+
+    <cfswitch expression="#Arguments.expires#">
+        <cfcase value="">
+        </cfcase>
+        <cfcase value="now">
+            <cfset expDate = DateAdd('d',-1,Now())>
+        </cfcase>
+        <cfcase value="never">
+            <cfset expDate = DateAdd('yyyy',30,Now())>
+        </cfcase>
+        <cfdefaultcase>
+            <cfif IsDate(Arguments.expires)>
+                <cfset expDate = Arguments.expires>
+            <cfelseif IsNumeric(Arguments.expires)>
+                <cfset expDate = DateAdd('d',Arguments.expires,Now())>
+            </cfif>
+        </cfdefaultcase>
+    </cfswitch>
+    <cfif IsDate(expDate) gt 0>
+        <cfset expDate = DateConvert('local2Utc',expDate)>
+        <cfset c = c & "expires=#DateFormat(expDate, 'ddd, dd-mmm-yyyy')# #TimeFormat(expDate, 'HH:mm:ss')# GMT;">
+    </cfif>
+    <cfif Len(Arguments.domain) gt 0>
+        <cfset c = c & "domain=#Arguments.domain#;">
+    </cfif>
+    <cfif Len(Arguments.path) gt 0>
+        <cfset c = c & "path=#Arguments.path#;">
+    </cfif>
+    <cfif Arguments.secure>
+        <cfset c = c & "secure;">
+    </cfif>
+    <cfif Arguments.httponly>
+        <cfset c = c & "HttpOnly;">
+    </cfif>
+    <cfheader name="SET-COOKIE" value="#c#" />
 </cffunction>
 
 <cffunction name="fixQueryPaths" output="false">

--- a/requirements/mura/utility.cfc
+++ b/requirements/mura/utility.cfc
@@ -491,96 +491,25 @@ Blog: www.codfusion.com--->
 </cffunction>
 
 <cffunction name="setSessionCookies">
-	<cfif application.configBean.getSecureCookies() or len(application.configBean.getSessionCookiesExpires())>
-		<cftry>
-			<cfif isdefined('session.CFID')>
-				<!--- Lucee uses lowercase cookies the setCookie method allows it to maintain case--->
-				<cfif server.coldfusion.productname neq 'Coldfusion Server'>
-					<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
-						<cfset setCookie('cfid', session.CFID,"", "", "/", application.configBean.getSecureCookies(), true, true)>
-						<cfset setCookie('cftoken', session.CFTOKEN, "", "", "/", application.configBean.getSecureCookies(), true, true)>
-					<cfelse>
-						<cfset setCookie('cfid', session.CFID, application.configBean.getSessionCookiesExpires(), "", "/", application.configBean.getSecureCookies(), true, true)>
-						<cfset setCookie('cftoken', session.CFTOKEN, application.configBean.getSessionCookiesExpires(), "", "/", application.configBean.getSecureCookies(), true, true)>
-					</cfif>
-				<cfelse>
-					<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
-						<cfcookie name="CFID" value="#session.CFID#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-						<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-					<cfelse>
-						<cfcookie name="CFID" value="#session.CFID#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-						<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-					</cfif>
-				</cfif>
+	<cftry>
+		<cfif isdefined('session.CFID')>
+			<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
+				<cfcookie name="CFID" value="#session.CFID#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+			<cfelse>
+				<cfcookie name="CFID" value="#session.CFID#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				<cfcookie name="CFTOKEN" value="#session.CFTOKEN#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 			</cfif>
-			<cfif isdefined('session.jsessionid')>
-				<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
-					<cfcookie name="JSESSIONID" value="#session.jsessionid#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-				<cfelse>
-					<cfcookie name="JSESSIONID" value="#session.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-				</cfif>
+		</cfif>
+		<cfif isdefined('session.jsessionid')>
+			<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
+				<cfcookie name="JSESSIONID" value="#session.jsessionid#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+			<cfelse>
+				<cfcookie name="JSESSIONID" value="#session.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 			</cfif>
-		<cfcatch></cfcatch>
-		</cftry>
-	</cfif>
-</cffunction>
-
-<!---
-Blog:http://www.modernsignal.com/coldfusionhttponlycookie--->
-<cffunction name="SetCookie" hint="Replacement for cfcookie that handles httponly cookies" output="false" returntype="void">
-    <cfargument name="name" type="string" required="true">
-    <cfargument name="value" type="string" required="true">
-    <cfargument name="expires" type="any" default="" hint="''=session only|now|never|[date]|[number of days]">
-    <cfargument name="domain" type="string" default="">
-    <cfargument name="path" type="string" default="/">
-    <cfargument name="secure" type="boolean" default="false">
-    <cfargument name="httponly" type="boolean" default="false">
-    <cfargument name="maintainCase" type="boolean" default="false">
-    <cfset var c = "">
-    <cfset var expDate = "">
-
-	<cfif arguments.maintainCase>
-		<cfset c = "#name#=#value#;">
-	<cfelseif server.coldfusion.productname eq "BlueDragon">
-		<cfset c = "#LCase(name)#=#value#;">
-	<cfelse>
-		<cfset c = "#UCase(name)#=#value#;">
-	</cfif>
-
-    <cfswitch expression="#Arguments.expires#">
-        <cfcase value="">
-        </cfcase>
-        <cfcase value="now">
-            <cfset expDate = DateAdd('d',-1,Now())>
-        </cfcase>
-        <cfcase value="never">
-            <cfset expDate = DateAdd('yyyy',30,Now())>
-        </cfcase>
-        <cfdefaultcase>
-            <cfif IsDate(Arguments.expires)>
-                <cfset expDate = Arguments.expires>
-            <cfelseif IsNumeric(Arguments.expires)>
-                <cfset expDate = DateAdd('d',Arguments.expires,Now())>
-            </cfif>
-        </cfdefaultcase>
-    </cfswitch>
-    <cfif IsDate(expDate) gt 0>
-        <cfset expDate = DateConvert('local2Utc',expDate)>
-        <cfset c = c & "expires=#DateFormat(expDate, 'ddd, dd-mmm-yyyy')# #TimeFormat(expDate, 'HH:mm:ss')# GMT;">
-    </cfif>
-    <cfif Len(Arguments.domain) gt 0>
-        <cfset c = c & "domain=#Arguments.domain#;">
-    </cfif>
-    <cfif Len(Arguments.path) gt 0>
-        <cfset c = c & "path=#Arguments.path#;">
-    </cfif>
-    <cfif Arguments.secure>
-        <cfset c = c & "secure;">
-    </cfif>
-    <cfif Arguments.httponly>
-        <cfset c = c & "HttpOnly;">
-    </cfif>
-    <cfheader name="SET-COOKIE" value="#c#" />
+		</cfif>
+	<cfcatch></cfcatch>
+	</cftry>
 </cffunction>
 
 <cffunction name="fixQueryPaths" output="false">


### PR DESCRIPTION
It's up to the browser to choose which to use. As we need to be sure it's secure, httpOnly and expires when we configured we need to set cookies only via utility.setSessionCookies(). 

I've also remove the setCookie function. I've tested Lucee 4.5, and it works with CFID lower or upper case cookies.

@mattlevine I see you've had issues with properly setting cookies (e.g. on Lucee). If you have any issues, feel free to contact me: jvz@bridgevest.com