### PR TITLE
Improvements to getNextN() method

### DIFF
--- a/requirements/mura/utility.cfc
+++ b/requirements/mura/utility.cfc
@@ -109,10 +109,14 @@
 		<cfset nextn.firstPage= 1 />
 	</cfif>
 
-	<cfset nextN.lastPage =nextn.firstPage + (2 * arguments.pageBuffer) + 1/>
+	<cfset nextN.lastPage =nextn.firstPage + (2 * arguments.pageBuffer)/>
 
 	<cfif nextn.NumberOfPages lt nextN.lastPage>
 		<cfset nextN.lastPage=nextn.NumberOfPages />
+	</cfif>
+
+	<cfif (nextn.lastPage - nextn.firstPage) lt (2 * arguments.pageBuffer)>
+		<cfset nextn.firstPage = max(1, nextn.lastPage - (2 * arguments.pageBuffer)) />
 	</cfif>
 
 	<cfset nextn.next=nextn.CurrentPageNumber+1 />


### PR DESCRIPTION
Addresses two issues:

1. Will now show the same number of pages (pageBuffer) above and below the current page. Previously would show (pageBuffer + 1) pages above the current page.

2. Will now consistently show (2 * pageBuffer) pages in addition to the current page. Previously, if you were at the end of the pages, it would only show (pageBuffer) pages before, unlike if you're on the first page, when it would show (2 * pageBuffer) pages after the current page.