### PR TITLE
Improvement to urlSafeFormat() method

### DIFF
--- a/requirements/mura/content/contentUtility.cfc
+++ b/requirements/mura/content/contentUtility.cfc
@@ -1964,6 +1964,7 @@ and parentID is null
 		arguments.str=approximate(arguments.str);
 		arguments.str=deaccent(arguments.str);
 		arguments.str=reReplace(arguments.str,'<[^>]*>','','all');
+		arguments.str=reReplace(arguments.str,"'",'','all');
 		arguments.str=rereplace(arguments.str,'[^a-zA-Z0-9\#arguments.delim#]',arguments.delim,'all');
 		arguments.str=rereplace(arguments.str,'\#arguments.delim#+',arguments.delim,'all');
 		arguments.str=rereplace(arguments.str,'^#arguments.delim#','','all');


### PR DESCRIPTION
Remove apostrophes so they don't get replaced with dashes.
For instance, content with the title "Kelly's Heroes" should generate the url "kellys-heroes" instead of "kelly-s-heroes"