### PR TITLE
Enabling the browsers built in spell checker

### DIFF
--- a/requirements/ckeditor/config.js.cfm
+++ b/requirements/ckeditor/config.js.cfm
@@ -61,7 +61,8 @@ CKEDITOR.editorConfig = function( config )
 		config.format_h4 = { element : '#renderer.getHeaderTag('subHead4')#' };
 	</cfif>
 	</cfoutput>
-
+	
+	config.disableNativeSpellChecker = false;
 	config.startupFocus = false;
 	config.skin = 'moono'; // 'bootstrapck'
 	config.allowedContent = {


### PR DESCRIPTION
By default CKEditor disables the browser built in spell checker, however Mura doesn't include the CKEditor spell checker plugin. By adding this configuration option it re-enables the browser built in spell checker:

http://docs.ckeditor.com/#!/guide/dev_spellcheck