### PR TITLE
Changed the default map provider.  Issue #2383

### DIFF
--- a/requirements/ckeditor/plugins/leaflet/dialogs/leaflet.js
+++ b/requirements/ckeditor/plugins/leaflet/dialogs/leaflet.js
@@ -221,7 +221,7 @@ CKEDITOR.dialog.add('leaflet', function(editor) {
 
                 else {
                   // Set the default value.
-                  this.setValue('MapQuestOpen.OSM');
+                  this.setValue('OpenStreetMap.Mapnik');
                 }
               },
 


### PR DESCRIPTION
I changed the default map provider from Mapquest to OpenStreetMap since it appears that Mapquest has discontinued the API that was being used. 

Issue #2383