### PR TITLE
PCI scan failing on the existence of CFID cookie when using jsessionid

### DIFF
--- a/requirements/mura/utility.cfc
+++ b/requirements/mura/utility.cfc
@@ -564,7 +564,13 @@ Blog: www.codfusion.com--->
 	<cfif application.configBean.getSecureCookies() or len(application.configBean.getSessionCookiesExpires())>
 		<cftry>
 			<cfset var sessionData=getSession()>
-			<cfif isdefined('sessionData.CFID')>
+			<cfif isdefined('sessionData.jsessionid')>
+				<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
+					<cfcookie name="JSESSIONID" value="#sessionData.jsessionid#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				<cfelse>
+					<cfcookie name="JSESSIONID" value="#sessionData.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
+				</cfif>
+			<cfelseif isdefined('sessionData.CFID')>
 				<!--- Lucee uses lowercase cookies the setCookie method allows it to maintain case--->
 				<cfif server.coldfusion.productname neq 'Coldfusion Server'>
 					<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
@@ -582,13 +588,6 @@ Blog: www.codfusion.com--->
 						<cfcookie name="CFID" value="#sessionData.CFID#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 						<cfcookie name="CFTOKEN" value="#sessionData.CFTOKEN#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 					</cfif>
-				</cfif>
-			</cfif>
-			<cfif isdefined('sessionData.jsessionid')>
-				<cfif application.configBean.getSessionCookiesExpires() EQ "" OR application.configBean.getSessionCookiesExpires() EQ "session">
-					<cfcookie name="JSESSIONID" value="#sessionData.jsessionid#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
-				<cfelse>
-					<cfcookie name="JSESSIONID" value="#sessionData.jsessionid#" expires="#application.configBean.getSessionCookiesExpires()#" secure="#application.configBean.getSecureCookies()#" httpOnly="true"/>
 				</cfif>
 			</cfif>
 		<cfcatch></cfcatch>


### PR DESCRIPTION
A PCI scan of our website revealed that CFID and CFTOKEN cookies were being set even though we have our ColdFusion server set to use J2EE session variables (jsessionid).  It is my understanding that when you have the server configured to use jsessionid the CFID and CFTOKEN values are not used and are no longer necessary.  They are known to be predictable (well the CFID part anyway).

NOTE: I'm not positive if the same applies to Lucee/Railo although I would presume that to be the case. I will leave that up to you guys to confirm.  We are using Adobe CF.

NOTE: This code only runs if you have set the secureCookies value to "true" in the settings.ini.cfm file.  With newer versions of ColdFusion (Adobe at least, version 10+) you can set the session cookies to be secure using the CF administrator.
