### PR TITLE
Create cacheFactory.cfc

### DIFF
--- a/requirements/mura/cache/cacheFactory.cfc
+++ b/requirements/mura/cache/cacheFactory.cfc
@@ -1,0 +1,2 @@
+component extends="mura.cache.cacheSimple" {
+}


### PR DESCRIPTION
Not sure if you want to include this or not but with the default cache refactoring, using MuraCache plugin breaks since it extends mura.cache.cacheFactory