### PR TITLE
Fix Reset Password being usable more than once

### DIFF
--- a/requirements/mura/user/userUtility.cfc
+++ b/requirements/mura/user/userUtility.cfc
@@ -786,6 +786,7 @@ Thanks for using #contactName#</cfoutput>
 			<cfset var user=redirect.getUser()>
 			<cfif user.exists()>
 				<cfset user.login()>
+				<cfset redirect.delete()>
 			</cfif>
 			<cfset structDelete(session,"siteArray")>
 		</cfif>


### PR DESCRIPTION
Issue: Reset password links work for 24 hours after request
Solution: Delete the redirect token after they have logged in with the token.

Alternative (probably better) solution: Delete the token after the password is changed.

I hope this works.