### PR TITLE
Adding comment to renderHTMLQueue()

### DIFF
--- a/requirements/mura/content/contentRenderer.cfc
+++ b/requirements/mura/content/contentRenderer.cfc
@@ -2506,6 +2506,7 @@ Display Objects
 				<cfset i=HTMLQueue[item]>
 
 				<cfif refind('[<>]',i)>
+					<!--- If we got just an in-line block of HTML markup and not a "real" file, render accordingly --->
 						<cfset itemStr=i>
 				<cfelse>
 					<cfset itemStr=""/>


### PR DESCRIPTION
Looking into some issues earlier, Evan and I thought renderHTMLHeadQueue() only accepted file paths. Turns out you can pass it an in-line chunk of HTML markup too, which is exactly what we needed.  I was half way into creating this functionality as a pull request when we saw the 2 lines of code that do that already. So I just added a small comment to that section of renderHTMLQueue() to make it a little easier to find.