### PR TITLE
Fixes to Edit Group page

### DIFF
--- a/admin/core/views/cusers/editgroup.cfm
+++ b/admin/core/views/cusers/editgroup.cfm
@@ -45,6 +45,7 @@
 	modified version; it is your choice whether to do so, or to make such modified version available under the GNU General Public License
 	version 2 without this exception.  You may, if you choose, apply this exception to your own modified versions of Mura CMS.
 --->
+
 <cfhtmlhead text="#session.dateKey#" />
 <cfhtmlhead text='<script type="text/javascript" src="assets/js/user.js"></script>'>
 <cfsilent>
@@ -102,90 +103,84 @@
 <!--- Header --->
 <cfoutput>
 	<div class="mura-header">
-			<h1>#rbKey('user.groupform')#</h1>
-			<div class="nav-module-specific btn-group">
-				<a class="btn" href="##" title="#esapiEncode('html',rbKey('sitemanager.back'))#" onclick="actionModal();window.history.back(); return false;">
-						<i class="mi-arrow-circle-left"></i>
-					#rbKey('sitemanager.back')#
+		<h1>#rbKey('user.groupform')#</h1>
+		<div class="nav-module-specific btn-group">
+			<a class="btn" href="##" title="#esapiEncode('html',rbKey('sitemanager.back'))#" onclick="actionModal();window.history.back(); return false;">
+					<i class="mi-arrow-circle-left"></i>
+				#rbKey('sitemanager.back')#
+			</a>
+			<a class="btn" href="#buildURL(action='cusers.list')#" onclick="actionModal();">
+					<i class="mi-users"></i>
+				#rbKey('user.viewallgroups')#
+			</a>
+			<cfif !rc.userBean.getIsNew()>
+				<a class="btn" href="#buildURL(action='cusers.editgroupmembers', querystring='userid=#rc.userid#&siteid=#esapiEncode('url',rc.siteid)#')#" onclick="actionModal();">
+						<i class="mi-group"></i>
+					#rbKey('user.viewgroupsusers')#
 				</a>
-				<a class="btn" href="#buildURL(action='cusers.list')#" onclick="actionModal();">
-						<i class="mi-users"></i>
-					#rbKey('user.viewallgroups')#
-				</a>
-				<cfif !rc.userBean.getIsNew()>
-					<a class="btn" href="#buildURL(action='cusers.editgroupmembers', querystring='userid=#rc.userid#&siteid=#esapiEncode('url',rc.siteid)#')#" onclick="actionModal();">
-							<i class="mi-group"></i>
-						#rbKey('user.viewgroupsusers')#
-					</a>
-				</cfif>
-			</div>
+			</cfif>
+		</div>
 	</div> <!-- /.mura-header -->
-</cfoutput>
 
-<!--- Edit Form --->
-	<cfoutput>
-		<cfif not structIsEmpty(rc.userBean.getErrors())>
-			<div class="alert alert-error"><span>#application.utility.displayErrors(rc.userBean.getErrors())#</span></div>
-		</cfif>
+	<!--- Edit Form --->
+	<cfif not structIsEmpty(rc.userBean.getErrors())>
+		<div class="alert alert-error"><span>#application.utility.displayErrors(rc.userBean.getErrors())#</span></div>
+	</cfif>
 
-		<form novalidate="novalidate" action="#buildURL(action='cUsers.update', querystring='userid=#rc.userBean.getUserID()#')#" enctype="multipart/form-data" method="post" name="form1" onsubmit="return userManager.submitForm(this);">
+	<form novalidate="novalidate" action="#buildURL(action='cUsers.update', querystring='userid=#rc.userBean.getUserID()#')#" enctype="multipart/form-data" method="post" name="form1" onsubmit="return userManager.submitForm(this);">
 
 		<div class="block block-constrain">
-	</cfoutput>
 
-		<cfif rsSubTypes.recordcount or arrayLen(pluginEventMappings)>
-				<ul class="mura-tabs nav-tabs">
-					<cfoutput>
-						<li class="active">
-							<a href="##tabBasic" onclick="return false;"><span>#esapiEncode('html',rbKey('user.basic'))#</span></a>
+			<cfif rsSubTypes.recordcount or arrayLen(pluginEventMappings)>
+				<ul class="mura-tabs nav-tabs" data-toggle="tabs">
+					<!--- Basic --->
+					<li class="active">
+						<a href="##tabBasic" onclick="return false;"><span>#esapiEncode('html',rbKey('user.basic'))#</span></a>
+					</li>
+
+					<!--- Extended Attributes --->
+					<cfif rsSubTypes.recordcount>
+						<li id="tabExtendedattributesLI" class="hide">
+							<a href="##tabExtendedattributes" onclick="return false;">
+								<span>#esapiEncode('html',rbKey('user.extendedattributes'))#</span>
+							</a>
 						</li>
-						<cfif rsSubTypes.recordcount>
-							<li id="tabExtendedattributesLI" class="hide">
-								<a href="##tabExtendedattributes" onclick="return false;">
-									<span>#esapiEncode('html',rbKey('user.extendedattributes'))#</span>
+					</cfif>
+
+					<cfif arrayLen(pluginEventMappings)>
+						<cfloop from="1" to="#arrayLen(pluginEventMappings)#" index="i">
+							<cfset tabID="tab" & $.createCSSID(pluginEventMappings[i].pluginName)>
+							<li id="###tabID#LI">
+								<a href="###tabID#" onclick="return false;">
+									<span>#esapiEncode('html',pluginEventMappings[i].pluginName)#</span>
 								</a>
 							</li>
-						</cfif>
-					</cfoutput>
-					<cfif arrayLen(pluginEventMappings)>
-						<cfoutput>
-							<cfloop from="1" to="#arrayLen(pluginEventMappings)#" index="i">
-								<cfset tabID="tab" & $.createCSSID(pluginEventMappings[i].pluginName)>
-								<li id="###tabID#LI">
-									<a href="###tabID#" onclick="return false;">
-										<span>#esapiEncode('html',pluginEventMappings[i].pluginName)#</span>
-									</a>
-								</li>
-							</cfloop>
-						</cfoutput>
+						</cfloop>
 					</cfif>
 				</ul>
 
 				<div class="tab-content block-content">
 					<div id="tabBasic" class="tab-pane active">
+			</cfif>
 
-
-		</cfif>
-
-		<cfoutput>
-		<div class="block block-bordered">
-			<cfif rsSubTypes.recordcount or arrayLen(pluginEventMappings)>
-				<!-- block header -->
-				<div class="block-header">
-					<h3 class="block-title">Basic Settings</h3>
-				</div> <!-- /.block header -->
+			<div class="block block-bordered">
+				<cfif rsSubTypes.recordcount or arrayLen(pluginEventMappings)>
+					<!-- block header -->
+					<div class="block-header">
+						<h3 class="block-title">Basic Settings</h3>
+					</div> <!-- /.block header -->
 				</cfif>
+			
 				<div class="block-content">
-
-				<!---
-					Group Type
-					** Only allow 'Admin' or Super Users to modify Group Types
-				--->
-				<cfif rc.isAdmin and not rc.userbean.getPerm()>
-					<div class="mura-control-group">
-						<label>
-							#rbKey('user.grouptype')#
-						</label>
+					<!---
+						Group Type
+						** Only allow 'Admin' or Super Users to modify Group Types
+					--->
+					<cfif rc.isAdmin and not rc.userbean.getPerm()>
+						<div class="mura-control-group">
+							<label>
+								#rbKey('user.grouptype')#
+							</label>
 							<label class="radio inline">
 								<input name="isPublic" type="radio" class="radio inline" value="1" <cfif rc.tempIsPublic>Checked</cfif>>
 								#rbKey('user.membergroup')#
@@ -195,15 +190,15 @@
 									#rbKey('user.systemgroup')#
 							</label>
 						</div>
-				<cfelse>
-					<input type="hidden" name="isPublic" value="#rc.tempIsPublic#">
-				</cfif>
+					<cfelse>
+						<input type="hidden" name="isPublic" value="#rc.tempIsPublic#">
+					</cfif>
 
-				<cfif rsNonDefault.recordcount>
-					<div class="mura-control-group">
-						<label>
-							#rbKey('user.type')#
-						</label>
+					<cfif rsNonDefault.recordcount>
+						<div class="mura-control-group">
+							<label>
+								#rbKey('user.type')#
+							</label>
 							<select name="subtype" onchange="userManager.resetExtendedAttributes('#rc.userBean.getUserID()#','1',this.value,'#userPoolID#','#application.configBean.getContext()#','#application.settingsManager.getSite(rc.siteID).getThemeAssetPath()#');">
 								<option value="Default" <cfif  rc.userBean.getSubType() eq "Default">selected</cfif>>
 									#rbKey('user.default')#
@@ -215,147 +210,138 @@
 								</cfloop>
 							</select>
 						</div>
-				</cfif>
+					</cfif>
 
-				<div class="mura-control-group">
+					<div class="mura-control-group">
 						<label>
 							#rbKey('user.groupname')#
 						</label>
-						<input type="text" name="groupname" value="#esapiEncode('html',rc.userBean.getgroupname())#" required="true" message="#rbKey('user.groupnamerequired')#" <cfif rc.userbean.getPerm()>readonly="readonly"</cfif>>
+						<input type="text" name="groupname" value="#esapiEncode('html',rc.userBean.getgroupname())#" required="required" message="#rbKey('user.groupnamerequired')#" <cfif rc.userbean.getPerm()>readonly="readonly"</cfif>>
 					</div>
 
-				<div class="mura-control-group">
+					<div class="mura-control-group">
 						<label>
-
-					<span data-toggle="popover" title="" data-placement="right"
-				  	data-content="#esapiEncode('html_attr',application.rbFactory.getKeyValue(session.rb,"user.groupemailmessage"))#"
-				  	data-original-title="#esapiEncode('html_attr',application.rbFactory.getKeyValue(session.rb,"user.groupemail"))#">
-								#rbKey('user.groupemail')#
+							<span data-toggle="popover" title="" data-placement="right"
+							  	data-content="#esapiEncode('html_attr',application.rbFactory.getKeyValue(session.rb,"user.groupemailmessage"))#"
+							  	data-original-title="#esapiEncode('html_attr',application.rbFactory.getKeyValue(session.rb,"user.groupemail"))#">
+									#rbKey('user.groupemail')#
 								<i class="mi-question-circle"></i>
 							</span>
 						</label>
 						<input type="text" name="email" value="#esapiEncode('html',rc.userBean.getemail())#">
-				</div>
-
-				<cfif not rc.userbean.getperm()>
-					<div class="mura-control-group">
-					<label>
-						#rbKey('user.tablist')#
-					</label>
-						<select name="tablist" multiple="true">
-							<option value=""<cfif not len(rc.userBean.getTablist())> selected</cfif>>All</option>
-							<cfloop list="#application.contentManager.getTabList()#" index="t">
-								<option value="#t#"<cfif listFindNoCase(rc.userBean.getTablist(),t)> selected</cfif>>
-									#rbKey("sitemanager.content.tabs.#REreplace(t, "[^\\\w]", "", "all")#")#
-								</option>
-							</cfloop>
-						</select>
 					</div>
-				</cfif>
 
-			<span id="extendSetsBasic"></span>
-
-
-			</div> <!-- /.block-content -->
-
-		</cfoutput>
+					<cfif not rc.userbean.getperm()>
+						<div class="mura-control-group">
+							<label>
+								#rbKey('user.tablist')#
+							</label>
+							<select name="tablist" multiple="multiple">
+								<option value=""<cfif not len(rc.userBean.getTablist())> selected</cfif>>All</option>
+								<cfloop list="#application.contentManager.getTabList()#" index="t">
+									<option value="#t#"<cfif listFindNoCase(rc.userBean.getTablist(),t)> selected</cfif>>
+										#rbKey("sitemanager.content.tabs.#REreplace(t, "[^\\\w]", "", "all")#")#
+									</option>
+								</cfloop>
+							</select>
+						</div>
+					</cfif>
+					<!--- <span id="extendSetsBasic"></span> --->
+				</div> <!-- /.block-content -->
 
 		<cfif rsSubTypes.recordcount or arrayLen(pluginEventMappings)>
-			</div> <!-- /.tab-pane -->
+				</div> <!-- / tabBasic -->		
+			</div> <!-- /.tab-content block-content -->
 
-			<cfif rsSubTypes.recordcount>
-				<div id="tabExtendedattributes" class='tab-pane'>
-					<div class="block block-bordered">
-						<!-- block header -->
-						<div class="block-header">
+				<cfif rsSubTypes.recordcount>
+					<div id="tabExtendedattributes" class='tab-pane'>
+						<div class="block block-bordered">
+							<!-- block header -->
+							<div class="block-header">
 								<h3 class="block-title">Extended Attributes</h3>
-						</div> <!-- /.block header -->
-						<div class="block-content">
-					<span id="extendSetsDefault"></span>
-						</div> <!-- /.block-content -->
-					</div> <!-- /.block-bordered -->
-				</div> <!-- /.tab-pane -->
-			</cfif>
+							</div> <!-- /.block header -->
+							<div class="block-content">
+								<span id="extendSetsDefault"></span>
+							</div> <!-- /.block-content -->
+						</div> <!-- /.block-bordered -->
+					</div> <!-- /.tab-pane -->
+				</cfif>
 
-			<cfif arrayLen(pluginEventMappings)>
-				<cfoutput>
+				<cfif arrayLen(pluginEventMappings)>
 					<cfloop from="1" to="#arrayLen(pluginEventMappings)#" index="i">
 						<cfset tabLabelList=listAppend(tabLabelList,pluginEventMappings[i].pluginName)/>
 						<cfset tabID="tab" & $.createCSSID(pluginEventMappings[i].pluginName)>
 						<cfset tabList=listAppend(tabList,tabID)>
 						<cfset pluginEvent.setValue("tabList",tabLabelList)>
 						<div id="#tabID#" class="tab-pane">
-						<div class="block block-bordered">
-							<!-- block header -->
-							<div class="block-header">
-						<h3 class="block-title">Plugin Events</h3>
-							</div> <!-- /.block header -->
-							<div class="block-content">
-							#$.getBean('pluginManager').renderEvent(eventToRender=pluginEventMappings[i].eventName,currentEventObject=$,index=i)#
-									</div> <!-- /.block-content -->
-								</div> <!-- /.block-bordered -->
-							</div> <!-- /.tab-pane -->
+							<div class="block block-bordered">
+								<!-- block header -->
+								<div class="block-header">
+									<h3 class="block-title">Plugin Events</h3>
+								</div> <!-- /.block header -->
+								<div class="block-content">
+									#$.getBean('pluginManager').renderEvent(eventToRender=pluginEventMappings[i].eventName,currentEventObject=$,index=i)#
+								</div> <!-- /.block-content -->
+							</div> <!-- /.block-bordered -->
+						</div> <!-- /.tab-pane -->
 					</cfloop>
-				</cfoutput>
-			</cfif>
-
-			<cfoutput>
-				</div> <!-- /.block-content.tab-content -->
-				<div class="mura-actions">
-					<div class="form-actions">
-						<cfif rc.userid eq ''>
-							<button type="button" class="btn mura-primary" onclick="submitForm(document.forms.form1,'add');"><i class="mi-check-circle"></i>#rbKey('user.add')#</button>
-						<cfelse>
-							<button type="button" class="btn" onclick="submitForm(document.forms.form1,'delete','#jsStringFormat(rbKey('user.deletegroupconfirm'))#');"><i class="mi-trash"></i>#rbKey('user.delete')#</button>
-							<button type="button" class="btn mura-primary" onclick="submitForm(document.forms.form1,'update');"><i class="mi-check-circle"></i>#rbKey('user.update')#</button>
-						</cfif>
-
-						<cfset tempAction = !Len(rc.userid) ? 'Add' : 'Update' />
-						<input type="hidden" name="action" value="#tempAction#">
-						<input type="hidden" name="type" value="1">
-						<input type="hidden" name="contact" value="0">
-						<input type="hidden" name="siteid" value="#esapiEncode('html',rc.siteid)#">
-						<input type="hidden" name="returnurl" value="#buildURL(action='cUsers.list', querystring='ispublic=#rc.tempIsPublic#')#">
-						<cfif not rsNonDefault.recordcount>
-							<input type="hidden" name="subtype" value="Default"/>
-						</cfif>
-						#rc.$.renderCSRFTokens(context=rc.userBean.getUserID(),format="form")#
-					</div>
-				</div>
-
-
-				<cfif rsSubTypes.recordcount>
-					<script type="text/javascript">
-						userManager.loadExtendedAttributes('#rc.userbean.getUserID()#','1','#rc.userbean.getSubType()#','#userPoolID#','#application.configBean.getContext()#','#application.settingsManager.getSite(rc.siteid).getThemeAssetPath()#');
-					</script>
 				</cfif>
-			</cfoutput>
-		<cfelse>
-			<cfoutput>
-				<div class="mura-actions">
-					<div class="form-actions">
-						<cfif rc.userid eq ''>
-							<button type="button" class="btn mura-primary" onclick="userManager.submitForm(document.forms.form1,'add');"><i class="mi-check-circle"></i>#rbKey('user.add')#</button>
-						<cfelse>
-							<button type="button" class="btn" onclick="submitForm(document.forms.form1,'delete','#jsStringFormat(rbKey('user.deletegroupconfirm'))#');"><i class="mi-trash"></i>#rbKey('user.delete')#</button>
-							<button type="button" class="btn mura-primary" onclick="userManager.submitForm(document.forms.form1,'update');"><i class="mi-check-circle"></i>#rbKey('user.update')#</button>
-						</cfif>
-						<cfset tempAction = !Len(rc.userid) ? 'Add' : 'Update' />
-						<input type="hidden" name="action" value="#tempAction#">
-						<input type="hidden" name="type" value="1"><!--- 1=group, 2=user --->
-						<input type="hidden" name="contact" value="0">
-						<input type="hidden" name="siteid" value="#esapiEncode('html_attr',rc.siteid)#">
-						<input type="hidden" name="returnurl" value="#buildURL(action='cUsers.list', querystring='ispublic=#rc.tempIsPublic#')#">
-						<cfif not rsNonDefault.recordcount>
-							<input type="hidden" name="subtype" value="Default"/>
-						</cfif>
-						#rc.$.renderCSRFTokens(context=rc.userBean.getUserID(),format="form")#
-					</div>
+
+			</div> <!-- /.block-content.tab-content -->
+		
+			<div class="mura-actions">
+				<div class="form-actions">
+					<cfif rc.userid eq ''>
+						<button type="button" class="btn mura-primary" onclick="submitForm(document.forms.form1,'add');"><i class="mi-check-circle"></i>#rbKey('user.add')#</button>
+					<cfelse>
+						<button type="button" class="btn" onclick="submitForm(document.forms.form1,'delete','#jsStringFormat(rbKey('user.deletegroupconfirm'))#');"><i class="mi-trash"></i>#rbKey('user.delete')#</button>
+						<button type="button" class="btn mura-primary" onclick="submitForm(document.forms.form1,'update');"><i class="mi-check-circle"></i>#rbKey('user.update')#</button>
+					</cfif>
+
+					<cfset tempAction = !Len(rc.userid) ? 'Add' : 'Update' />
+					<input type="hidden" name="action" value="#tempAction#">
+					<input type="hidden" name="type" value="1">
+					<input type="hidden" name="contact" value="0">
+					<input type="hidden" name="siteid" value="#esapiEncode('html',rc.siteid)#">
+					<input type="hidden" name="returnurl" value="#buildURL(action='cUsers.list', querystring='ispublic=#rc.tempIsPublic#')#">
+					<cfif not rsNonDefault.recordcount>
+						<input type="hidden" name="subtype" value="Default"/>
+					</cfif>
+					#rc.$.renderCSRFTokens(context=rc.userBean.getUserID(),format="form")#
 				</div>
-			</cfoutput>
+			</div>
+
+			<cfif rsSubTypes.recordcount>
+				<script type="text/javascript">
+					userManager.loadExtendedAttributes('#rc.userbean.getUserID()#','1','#rc.userbean.getSubType()#','#userPoolID#','#application.configBean.getContext()#','#application.settingsManager.getSite(rc.siteid).getThemeAssetPath()#');
+				</script>
+			</cfif>
+		<cfelse>
+			<!--- </div> ---> <!-- /.block-content -->
+			<div class="mura-actions">
+				<div class="form-actions">
+					<cfif rc.userid eq ''>
+						<button type="button" class="btn mura-primary" onclick="userManager.submitForm(document.forms.form1,'add');"><i class="mi-check-circle"></i>#rbKey('user.add')#</button>
+					<cfelse>
+						<button type="button" class="btn" onclick="submitForm(document.forms.form1,'delete','#jsStringFormat(rbKey('user.deletegroupconfirm'))#');"><i class="mi-trash"></i>#rbKey('user.delete')#</button>
+						<button type="button" class="btn mura-primary" onclick="userManager.submitForm(document.forms.form1,'update');"><i class="mi-check-circle"></i>#rbKey('user.update')#</button>
+					</cfif>
+					<cfset tempAction = !Len(rc.userid) ? 'Add' : 'Update' />
+					<input type="hidden" name="action" value="#tempAction#">
+					<input type="hidden" name="type" value="1"><!--- 1=group, 2=user --->
+					<input type="hidden" name="contact" value="0">
+					<input type="hidden" name="siteid" value="#esapiEncode('html_attr',rc.siteid)#">
+					<input type="hidden" name="returnurl" value="#buildURL(action='cUsers.list', querystring='ispublic=#rc.tempIsPublic#')#">
+					<cfif not rsNonDefault.recordcount>
+						<input type="hidden" name="subtype" value="Default"/>
+					</cfif>
+					#rc.$.renderCSRFTokens(context=rc.userBean.getUserID(),format="form")#
+				</div>
+			</div>
 		</cfif>
 
-		</div> <!-- /.block-bordered -->
-	</div> <!-- /.block-constrain -->
+		<!--- </div> ---> <!-- /.block-bordered -->
+		</div> <!-- /.block-constrain -->
 	</form>
-<!--- /Edit Form --->
+	<!--- /Edit Form --->
+</cfoutput>


### PR DESCRIPTION
On the "Edit Group" screen, the Extended Attributes were not always appearing correctly.  There were some broken tags causing 
the different "tab groups" to be stuck inside each other, rather than siblings.  This is now fixed.

Also A couple minor HTML validation issues (missing "data" attribute for the Tabs to work, required="true" changed to required="required" and multiple="true" changed to multiple="multiple" so the HTML is more valid).

Also removed several extraneous cfoutput tags and consolidated it into one so the code "indents more logically" making it easier to find the matching open/close tags for everything.

Note: I did reformat the indenting of the page a bit. I wouldn't normally do that to someone else's code, but given that the core of this bug fix was just finding which tags were open/closed, it helped to track down the missing tags.  If I were just fixing, say, typos or adding new functionality, I wouldn't change that kind of that. :)