### PR TITLE
Feed API sort( "mxpRelevance" ) enhancement

### DIFF
--- a/requirements/mura/content/feed/feedGateway.cfc
+++ b/requirements/mura/content/feed/feedGateway.cfc
@@ -1176,6 +1176,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 								<cfelse>
 									total_points desc, total_score desc
 								</cfif>
+								,tcontent.releaseDate desc, tcontent.lastUpdate desc <!--- tie-breaker sort options for articles with the same MXP points/scores. Show the most recent one first. --->
 							<cfelse>
 								#REReplace(arguments.feedBean.getOrderBy(),"[^0-9A-Za-z\._,\- ]","","all")#
 							</cfif>


### PR DESCRIPTION
Per the Intuit changes we discussed, if a feed returns multiple articles with the same MXP points/scores, it will pick "at random" from the result set, which often means a really old article is what's getting returned (based on how the database does default sorting).  This change will use "tcontent.releaseDate" as the tie breaker, and if "tcontent.releaseDate" is empty (it's not a required field), it will use tcontent.lastUpdate instead.