### PR TITLE
Fix for editor not loading in load balanced environment with SSL

### DIFF
--- a/requirements/ckeditor/config.js.cfm
+++ b/requirements/ckeditor/config.js.cfm
@@ -205,8 +205,10 @@ CKEDITOR.editorConfig = function( config )
 	config.oembed_WrapperClass = 'embeddedContent';
 
 <cfoutput>
-	<cfset secure=$.getBean('utility').isHTTPS()>
-
+	<cfset clientHeaders = GetHttpRequestData().headers />
+	<cfset isHTTPS = structKeyExists(clientHeaders,"X-Forwarded-Proto") AND clientHeaders["X-Forwarded-Proto"] EQ "https" />
+	<cfset secure=$.getBean('utility').isHTTPS() OR isHTTPS />
+	
 	<!--- contentsCss --->
 		config.contentsCss = [];
 


### PR DESCRIPTION
This fixes the secure lookup when SSL terminates at load balancer. This logic should probably go in the isHTTPS method, but I only saw issue with editor, so just adding it here to be safe.