### PR TITLE
Better default sorting for mxpRelevance

### DIFF
--- a/requirements/mura/bean/beanFeed.cfc
+++ b/requirements/mura/bean/beanFeed.cfc
@@ -816,7 +816,17 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 
 <cffunction name="sort" output="false">
 	<cfargument name="property">
-	<cfargument name="direction" default="asc">
+	<cfargument name="direction">
+	
+	<!--- default sort direction ASC for everything *except* mxpRelevance, which should be DESC so the highest point values are first. --->
+	<cfif not StructKeyExists( arguments, "direction" )>
+		<cfif arguments.property eq "mxpRelevance">
+			<cfset arguments.direction = "desc" />
+		<cfelse>
+			<cfset arguments.direction = "asc" />
+		</cfif>
+	</cfif>
+	
 	<cfset variables.instance.orderby=listAppend(variables.instance.orderby,arguments.property & ' ' & arguments.direction)>
 	<cfreturn this>
 </cffunction>


### PR DESCRIPTION
By default sort() uses ASC.  mxpRelevance should be DESC so the highest scores/points are first.  This change fixes the issue, while maintaining ASC as the default for everything else.