### PR TITLE
Fixed invalid attribute

### DIFF
--- a/admin/core/views/cextend/dsp_attribute_form.cfm
+++ b/admin/core/views/cextend/dsp_attribute_form.cfm
@@ -82,7 +82,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 
 <div class="mura-control-group">
 	<label>Name (No spaces)</label>
-		<input type="text" name="name" required="true" value="#esapiEncode('html_attr',attributes.attributeBean.getName())#" />
+		<input type="text" name="name" data-required="true" value="#esapiEncode('html_attr',attributes.attributeBean.getName())#" />
 </div>
 <div class="mura-control-group">
 	<label>Label</label>


### PR DESCRIPTION
The "name" field was using required="true" which is invalid HTML. Judging by the other validation code in Mura admin I think this is supposed to be data-required="true".  The form still works the same way and doesn't throw an HTML validation error now.