### PR TITLE
Added "keywords" as an option for the dsp_nextN.cfm pagination render…

### DIFF
--- a/default/includes/display_objects/collection/includes/dsp_nextN.cfm
+++ b/default/includes/display_objects/collection/includes/dsp_nextN.cfm
@@ -73,7 +73,7 @@
 <cfset variables.qrystr="" />
 
 <cfif len(trim($.event("keywords")))>
-	<cfset variables.qrystr="&keywords=" & encodeForHTMLAttribute( $.event("keywords") ) />
+	<cfset variables.qrystr="&keywords=" & encodeForURL( $.event("keywords") ) />
 </cfif>
 <cfif len(request.sortBy)>
 	<cfset variables.qrystr=variables.qrystr & "&sortBy=#request.sortBy#&sortDirection=#request.sortDirection#"/>

--- a/default/includes/display_objects/collection/includes/dsp_nextN.cfm
+++ b/default/includes/display_objects/collection/includes/dsp_nextN.cfm
@@ -63,6 +63,8 @@
 <cfparam name="request.startRow" default="1"/>
 <cfparam name="request.filterBy" default=""/>
 <cfparam name="request.currentNextNID" default=""/>
+<cfparam name="request.keywords" default=""/>
+
 <cfif variables.nextN.recordsPerPage gt 1>
 <cfset variables.paginationKey="startRow">
 <cfelse>
@@ -70,8 +72,11 @@
 </cfif>
 <cfset variables.qrystr="" />
 
+<cfif len(trim($.event("keywords")))>
+	<cfset variables.qrystr="&keywords=" & encodeForHTMLAttribute( $.event("keywords") ) />
+</cfif>
 <cfif len(request.sortBy)>
-	<cfset variables.qrystr="&sortBy=#request.sortBy#&sortDirection=#request.sortDirection#"/>
+	<cfset variables.qrystr=variables.qrystr & "&sortBy=#request.sortBy#&sortDirection=#request.sortDirection#"/>
 </cfif>
 <cfif len(variables.$.event('categoryID'))>
 	<cfset variables.qrystr=variables.qrystr & "&categoryID=#variables.$.event('categoryID')#"/>


### PR DESCRIPTION
Per conversation w/ Eddie, we’d like to have “keywords” be an option that the dsp_nextN.cfm file honors in the qrystr variable the way it does sortBy, SortDirection, etc.  This was added to the CSAC-EIA project as a hack (I’m not sure who did it), then got used in the MessageBoard plugin also for CSAC on Mura 6.2 and is now in use on SACRS (Mura 7) as well.  If we can make it a legit option in Mura 7 we can:

a) make this a new feature for Mura 7.
b) make CSAC’s code more update-safe, as the hack in their current 6.2 code will be a legit feature in Mura 7 core.
c) fix an issue in the SACRS project (pagination is broken on their Bulletin Board).