### PR TITLE
Fixed getCustomSetting value return

### DIFF
--- a/requirements/mura/plugin/pluginConfig.cfc
+++ b/requirements/mura/plugin/pluginConfig.cfc
@@ -374,6 +374,7 @@ component extends="mura.cfobject" output="false" hint="This provides access to a
 		} else if ( fileExists(wddxFile) ) {
 			customWDDX=fileRead(wddxFile,"utf-8");
 			variables.customSettings["#arguments.name#"]=getBean('utility').wddx2cfml(customWDDX);
+			customValue=variables.customSettings["#arguments.name#"];
 			return customValue;
 		} else {
 			if(isdefined('arguments.default')){


### PR DESCRIPTION
Added line 377 to set `customValue` to the value retrieved on line 376, thus can be returned to the user upon the _very_ first call to the function. Also fixes issue where `getCustomSetting` would return an empty string for the very first call, regardless of the default parameter or value obtained.