### PR TITLE
Alter admin JS validation of page title to use form and element IDs to avoid element name conflicts

### DIFF
--- a/admin/assets/js/architecture.js
+++ b/admin/assets/js/architecture.js
@@ -237,13 +237,12 @@ var siteManager = {
 			}
 		}
 
-		if(document.contentForm.title.value == '') {
-			if(document.contentForm.type.value == 'Component') {
-
+		if( $('form#contentForm #title').val() === '') {
+			if( $('form#contentForm').prop('type').value == 'Component') {
 				alertDialog("The form field 'Menu Title' is required");
 				return false;
 
-			} else if(document.contentForm.type.value == 'Form') {
+			} else if( $('form#contentForm').prop('type').value == 'Form') {
 
 				alertDialog("The form field 'Title' is required");
 				return false;


### PR DESCRIPTION
If you create an extended attribute for a given class with the name 'title', upon re-entering the admin and creating/editing a page with that class, it will endlessly throw the JS validation error "The form field 'Long Title' is required", even if you supply a value for every possible field. Renaming the attribute to anything but 'title' (element-title, department-title, etc) removes this validation conflict. 

Revising the code to evaluate the title to use the form ID and the element ID to check it's value will remove the possibility of name conflicts with another input element in the same form. Additionally, this nomenclature is already used elsewhere in the same file. 