### PR TITLE
Making sure variable.collection is really a collection before checking keys.

### DIFF
--- a/requirements/mura/cache/cacheAbstract.cfc
+++ b/requirements/mura/cache/cacheAbstract.cfc
@@ -174,7 +174,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 
 	<cffunction name="keyExists" returntype="boolean" output="false">
 		<cfargument name="key">
-		<cfreturn structKeyExists( variables.collection , arguments.key ) />
+		<cfreturn isStruct( variables.collection ) and structKeyExists( variables.collection , arguments.key ) />
 	</cffunction>
 
 	<cffunction name="has" returntype="boolean" output="false">


### PR DESCRIPTION
We received some error reports stating: 'You have attempted to dereference a scalar variable of type class java.lang.String as a structure with members' at line 177 in requirements/mura/cache/cacheAbstract.cfc.
 
I think it is because the cache is still being created while an other request checking for keys.
I added a simple check to the keyExists function to make sure the collection is really a struct before checking keys.