### PR TITLE
Update onMissingTemplate_include.cfm

### DIFF
--- a/core/appcfc/onMissingTemplate_include.cfm
+++ b/core/appcfc/onMissingTemplate_include.cfm
@@ -118,8 +118,11 @@ if ( isDefined("application.contentServer") ) {
 	if ( listFind('_api,tasks',firstItem) ) {
 		writeOutput("#application.contentServer.handleAPIRequest('/' & local.filename)#");
 		abort;
+	} else if ( !len(cgi.path_info) ) {
+		// handle /missing.cfm/ file with 404 
+		application.contentServer.render404();
 	} else {
-
+	
 		local.fileArray=ListToArray(cgi.path_info,'\,/');
 		local.last=local.fileArray[arrayLen(local.fileArray)];
 		local.hasAllowedFile=find(".",local.last) and (application.configBean.getAllowedIndexFiles() eq '*' or listFind(application.configBean.getAllowedIndexFiles(),local.last));


### PR DESCRIPTION
There is probably a better way to handle this earlier on in the request, but 404s with a trailing slash after the filename (missing.cfm) currently fail in our environment with a 500 error instead of a 404. 

For example, a request for `domain.com/missing.cfm/` gets rewritten as `domain.com/missing.cfm/index.cfm`, and in these cases, cgi.path_info isn't populated causing `local.last=local.fileArray[arrayLen(local.fileArray)];` to fail