### PR TITLE
fix attachment download link for emails from form responses

### DIFF
--- a/core/mura/content/dataCollection/dataCollectionBean.cfc
+++ b/core/mura/content/dataCollection/dataCollectionBean.cfc
@@ -438,23 +438,20 @@ component extends="mura.bean.bean" entityname="dataCollection" hint="This provid
 						htmlString &= '<tr><td colspan="2" style="font-weight: bold">' & field.label & '</td></tr>';
 					} else {
 						if (StructKeyExists(formResult, field.name)) {
-							if(findNoCase('attachment', field.name) and isValid("UUID",formResult['#field.name#'])){
-								var redirectid=createUUID();
-								var userRedirect=getBean('userRedirect').set(
-									{
-										redirectid=redirectid,
-										url="#arguments.$.siteConfig().getResourcePath(complete=1)#/index.cfm/_api/render/file/?fileID=#formResult['#field.name#']#&method=attachment",
-										siteid=arguments.$.siteConfig('siteid'),
-										created=now()
+							field.value = esapiEncode('html', formResult[field.name]);
+						} else if (findNoCase('attachment', field.name)) {
+							var redirectid=createUUID();
+							var userRedirect=getBean('userRedirect').set(
+								{
+									redirectid=redirectid,
+									url="#arguments.$.siteConfig().getResourcePath(complete=1)#/index.cfm/_api/render/file/?fileID=#formResult['#field.name#_attachment']#&method=attachment",
+									siteid=arguments.$.siteConfig('siteid'),
+									created=now()
+								}).save();
 
-									}).save();
-
-
-								field.value &= '<a href="#arguments.$.siteConfig().getWebPath(complete=1)##arguments.$.siteConfig().getContentRenderer().getURLStem(arguments.$.siteConfig('siteid'),redirectid)#" target="_blank">Download</a>';
-							} else {
-								field.value = esapiEncode('html', formResult[field.name]);
-							}
+							field.value &= '<a href="#arguments.$.siteConfig().getWebPath(complete=1)##arguments.$.siteConfig().getContentRenderer().getURLStem(arguments.$.siteConfig('siteid'),redirectid)#" target="_blank">Download</a>';
 						}
+
 						htmlString &= '<tr><td style="vertical-align: top; min-width: 100px">' & field.label & '</td><td>' & field.value & '</td></tr>';
 					}
 				}


### PR DESCRIPTION
This PR fixes the logic for setting the field.value property. It also adds "_attachment" to the value of field.name, as this seems to be appended inside the getValidations method (line 175). 