### PR TITLE
fix getDSPIncludePath

### DIFF
--- a/core/mura/settings/settingsBean.cfc
+++ b/core/mura/settings/settingsBean.cfc
@@ -1969,7 +1969,7 @@ component extends="mura.bean.beanExtendable" entityName="site" table="tsettings"
 			return variables.dspincludepath;
 		} else {
 			variables.dspincludepath="#getIncludePath()#/includes";
-			if(!directoryExists(variables.dspincludepath)){
+			if(!directoryExists(expandPath(variables.dspincludepath))){
 				variables.dspincludepath=getIncludePath();
 			}
 			return variables.dspincludepath;


### PR DESCRIPTION
add expandPath so that it can properly verify legacy includes directory