### PR TITLE
 Removing unnecessary querySetCell calls in related content logic

### DIFF
--- a/admin/core/views/carch/loadselectedrelatedcontent.cfm
+++ b/admin/core/views/carch/loadselectedrelatedcontent.cfm
@@ -69,11 +69,6 @@
 						<cfloop list="#rcsRs.columnlist#" index="c">
 							<cfset querySetCell(rcsRs, lcase(c),item[c], rcsRs.recordcount)>
 						</cfloop>
-						<cfif StructKeyExists(StructKeyExists, "")>
-							<cfset querySetCell(rcsRs, '', 0, rcsRs.recordcount)>
-						</cfif>
-						<cfset querySetCell(rcsRs, 'type', 'Link', rcsRs.recordcount)>
-						<cfset querySetCell(rcsRs, 'subtype', 'Default', rcsRs.recordcount)>
 					</cfif>
 				</cfif>
 			</cfloop>

--- a/admin/core/views/carch/loadselectedrelatedcontent.cfm
+++ b/admin/core/views/carch/loadselectedrelatedcontent.cfm
@@ -69,7 +69,9 @@
 						<cfloop list="#rcsRs.columnlist#" index="c">
 							<cfset querySetCell(rcsRs, lcase(c),item[c], rcsRs.recordcount)>
 						</cfloop>
-						<cfset querySetCell(rcsRs, '', 0, rcsRs.recordcount)>
+						<cfif StructKeyExists(StructKeyExists, "")>
+							<cfset querySetCell(rcsRs, '', 0, rcsRs.recordcount)>
+						</cfif>
 						<cfset querySetCell(rcsRs, 'type', 'Link', rcsRs.recordcount)>
 						<cfset querySetCell(rcsRs, 'subtype', 'Default', rcsRs.recordcount)>
 					</cfif>

--- a/core/mura/extend/extendData.cfc
+++ b/core/mura/extend/extendData.cfc
@@ -383,7 +383,12 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 				</cfif>
 			<cfelse>
 				<cftry>
-					<cfset extData.data['#arguments.rs.name#']=getContentRenderer().setDynamicContent(arguments.rs.defaultValue)>
+					<cfset var returnExtendedAttributeDefaultWhenEmptyAttributeValue=variables.configBean.getValue(property='returnExtendedAttributeDefaultWhenEmptyAttributeValue',defaultValue=true)>
+					<cfif yesNoFormat(returnExtendedAttributeDefaultWhenEmptyAttributeValue)>
+						<cfset extData.data['#arguments.rs.name#']=getContentRenderer().setDynamicContent(arguments.rs.defaultValue)>
+					<cfelse>
+						<cfset extData.data['#arguments.rs.name#']=''>
+					</cfif>
 					<cfcatch><cfset extData.data['#arguments.rs.name#']=''></cfcatch>
 				</cftry>
 			</cfif>

--- a/core/mura/extend/extendData.cfc
+++ b/core/mura/extend/extendData.cfc
@@ -383,12 +383,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 				</cfif>
 			<cfelse>
 				<cftry>
-					<cfset var returnExtendedAttributeDefaultWhenEmptyAttributeValue=variables.configBean.getValue(property='returnExtendedAttributeDefaultWhenEmptyAttributeValue',defaultValue=true)>
-					<cfif yesNoFormat(returnExtendedAttributeDefaultWhenEmptyAttributeValue)>
-						<cfset extData.data['#arguments.rs.name#']=getContentRenderer().setDynamicContent(arguments.rs.defaultValue)>
-					<cfelse>
-						<cfset extData.data['#arguments.rs.name#']=''>
-					</cfif>
+					<cfset extData.data['#arguments.rs.name#']=getContentRenderer().setDynamicContent(arguments.rs.defaultValue)>
 					<cfcatch><cfset extData.data['#arguments.rs.name#']=''></cfcatch>
 				</cftry>
 			</cfif>


### PR DESCRIPTION
This is a fix to the issue reported here: https://github.com/blueriver/MuraCMS/pull/2640