### PR TITLE
Fix toggle for view unassigned users

### DIFF
--- a/admin/core/views/cusers/listusers.cfm
+++ b/admin/core/views/cusers/listusers.cfm
@@ -90,7 +90,7 @@
 		<div class="mura-control-group">
 
 			<!--- View All / Unassigned Only --->
-				<a class="btn" href="#buildURL(action='cusers.listusers', querystring='siteid=#esapiEncode('url',rc.siteid)#&ispublic=#esapiEncode('url',rc.ispublic)#&unassigned=#esapiEncode('url',rc.unassigned)#')#" onclick="actionModal();">
+				<a class="btn" href="#buildURL(action='cusers.listusers', querystring='siteid=#esapiEncode('url',rc.siteid)#&ispublic=#esapiEncode('url',rc.ispublic)#&unassigned=#esapiEncode('url',rc.unassigned)?0:1#')#" onclick="actionModal();">
 					<i class="mi-filter"></i>
 					<cfif rc.unassigned EQ 0>
 						#rbKey('user.viewunassignedonly')#


### PR DESCRIPTION
Clicking on the 'view unassigned users' button wasn't switching the value of 'unassigned' to 1 or back to 0 for 'view all'