### PR TITLE
Makes notes in components publisher sticky

### DIFF
--- a/admin/core/views/carch/form/dsp_tab_publishing.cfm
+++ b/admin/core/views/carch/form/dsp_tab_publishing.cfm
@@ -234,7 +234,7 @@
 		<label>
 			#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.addnotes')#
 		</label>
-		<textarea name="notes" rows="8" id="abstract"></textarea>
+		<textarea name="notes" rows="8" id="abstract">#application.rbFactory.getKeyValue(session.rb,"sitemanager.content.notes")#: #esapiEncode('html',rc.contentBean.getNotes())#</textarea>
 	</div> <!--- /end mura-control-group --->
 
    <span id="extendset-container-publishing" class="extendset-container"></span>


### PR DESCRIPTION
Notes get wiped out if you make an edit after you have published.
Added the notes bean content to the textarea.

e.g. Make a component, add notes > Publish
note appear.

Edit same component, (e.g. the body content). Now view the notes under publishing, the notes textarea is blank. Publishing removes all notes. Hopefully this is not by design, because if so that is flawed.

in template dsp_tab_publishing.cfm
change it to:
<textarea name="notes" rows="8" id="abstract">#application.rbFactory.getKeyValue(session.rb,"sitemanager.content.notes")#: #esapiEncode('html',rc.contentBean.getNotes())#</textarea>