### PR TITLE
Change to getCurrentFieldList in dataCollectionManager

### DIFF
--- a/requirements/mura/content/dataCollection/dataCollectionManager.cfc
+++ b/requirements/mura/content/dataCollection/dataCollectionManager.cfc
@@ -211,12 +211,13 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 		<cfset var dbType=variables.configBean.getDbType() />
 
 		<cfquery attributeCollection="#variables.configBean.getReadOnlyQRYAttrs(name='rs')#">
-			select distinct formField from tformresponsequestions
-			where formID= <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.formID#"/>
-			order by formField asc
+			SELECT responseDisplayFields
+			FROM tcontent
+			WHERE ContentID = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.formID#"/>
+			AND active = 1
 		</cfquery>
 
-		<cfreturn valueList(rs.formField) />
+		<cfreturn replace(rs.responseDisplayFields, "^", ",","all") />
 	</cffunction>
 
 	<cffunction name="getData" returntype="query" access="public" output="false">


### PR DESCRIPTION
A customer was complaining that since upgrading to Mura7, downloads of form data now had the fields ordered alphabetically rather than in the order they appeared in the form. 
This appears to be because the list of fields to display was being generated by getting a distinct list of all the form fields for that form in tformresponsequestions and then sorting them. I've updated the function to instead pull the fieldlist from the fieldlist field in tcontent as this preserves the ordering. It also will now only return the current field list as it's based on the active content item not the responses. Not sure if this is desired behaviour, but it does fit the name of the funciton more closely.