### PR TITLE
Fixes issue with the Trash Bin pagination

### DIFF
--- a/admin/core/views/ctrash/list.cfm
+++ b/admin/core/views/ctrash/list.cfm
@@ -120,7 +120,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 					 <cfif rc.pageNum eq i>
 						 <li class="active"><a href="##">#i#</a></li>
 					 <cfelse>
-						 <li><a href="?muraAction=cTrash.list&siteid=#esapiEncode('url',rc.siteid)#&keywords=#esapiEncode('url',rc.keywords)#&pageNum=#i#&sinceDate=#esapiEncode('html_attr',$.event('sinceDate'))#&sinceDate=#esapiEncode('url',$.event('sinceDate'))#&beforeDate=#esapiEncode('url',$.event('beforeDate'))#">#i#</a></li>
+						 <li><a href="?muraAction=cTrash.list&siteid=#esapiEncode('url',rc.siteid)#&keywords=#esapiEncode('url',rc.keywords)#&pageNum=#i#&sinceDate=#esapiEncode('url',$.event('sinceDate'))#&beforeDate=#esapiEncode('url',$.event('beforeDate'))#">#i#</a></li>
 					 </cfif>
 
 				 </cfloop>


### PR DESCRIPTION
The Trash Bin pagination URLs rendered the sinceDate parameter twice causing an invalid date exception. As a fix I removed one of them. 