### PR TITLE
Fix: Trash Bin pagination's next button

### DIFF
--- a/admin/core/views/ctrash/list.cfm
+++ b/admin/core/views/ctrash/list.cfm
@@ -124,9 +124,11 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 					 </cfif>
 
 				 </cfloop>
+				<cfif rc.pageNum lt rc.trashIterator.pageCount()>
 					<li>
-						<a href="?muraAction=cTrash.list&siteid=#esapiEncode('url',rc.siteid)#&keywords=#esapiEncode('url',rc.keywords)#&pageNum=#i#&sinceDate=#esapiEncode('url',$.event('sinceDate'))#&beforeDate=#esapiEncode('url',$.event('beforeDate'))#">#i#</a>
-			 		</li>
+						<a href="?muraAction=cTrash.list&siteid=#esapiEncode('url',rc.siteid)#&keywords=#esapiEncode('url',rc.keywords)#&pageNum=#pageNum + 1#&sinceDate=#esapiEncode('url',$.event('sinceDate'))#&beforeDate=#esapiEncode('url',$.event('beforeDate'))#"><i class="mi-angle-right"></i></a>
+					</li>
+				</cfif>
 			 </ul>
 		 </cfif>
 		 <cfelse>


### PR DESCRIPTION
I noticed the Trash Bin pagination rendered an extra page number after the iterator is done looping. I believe that was intended to render the Next button. 
I wrapped it into a conditional and made sure the right icon is rendered instead of a non-existing page  number. 