### PR TITLE
Potential fix for #2950. Add arguments for showNavOnly and showExcludeSearch to calendar module.

### DIFF
--- a/core/modules/v1/calendar/index.cfm
+++ b/core/modules/v1/calendar/index.cfm
@@ -184,6 +184,8 @@
 							, categoryid: '#esapiEncode('javascript',variables.$.event('categoryid'))#'
 							, tag: '#esapiEncode('javascript',variables.$.event('tag'))#'
 							, format: 'fullcalendar'
+							, showNavOnly: 0
+							, showExcludeSearch: 0
 						}
 						, color: '#this.calendarcolors[colorIndex].background#'
 						, textColor: '#this.calendarcolors[colorIndex].text#'

--- a/core/mura/content/contentCalendarUtilityBean.cfc
+++ b/core/mura/content/contentCalendarUtilityBean.cfc
@@ -43,6 +43,8 @@ component extends='mura.cfobject' hint="This provides content calendar utility m
     , tag='#variables.$.event('tag')#'
     , siteid='#variables.$.event('siteid')#'
     , returnFormat='query'
+		, showNavOnly=0
+		, showExcludeSearch=0
   ) {
     var tp = variables.$.initTracePoint('mura.content.contentCalendarUtilityBean.getCalendarItems');
     var local = {};
@@ -83,6 +85,8 @@ component extends='mura.cfobject' hint="This provides content calendar utility m
       .setMaxItems(0) // get all records
       .setNextN(0) // no pagination
       .setSiteID(arguments.siteid)
+			.setshowNavOnly(arguments.showNavOnly)
+			.setshowExcludeSearch(arguments.showExcludeSearch)
       .addParam(
         relationship='AND'
         ,field='tcontent.parentid'


### PR DESCRIPTION
Potential fix for #2950. This allows arguments to be passed to getCalendarItems() to also get content items that are not in the navigation or that have been excluded from site search.