### PR TITLE
Update installation.txt

### DIFF
--- a/Installation.txt
+++ b/Installation.txt
@@ -26,4 +26,4 @@ Installing Mura couldn't be easier. Follow the instructions below and you'll be 
 
 8. You're done installing Mura. Enjoy!
 
-For more information on Installation and Setup, please visit http://docs.getmura.com/v6/installation-setup/
+For more information on Installation and Setup, please visit https://docs.getmura.com/v7-1/installation-setup/installing-mura-codebase/


### PR DESCRIPTION
changes URL at the bottom of the text from Mura v 6.1 to working URL of 7.1 docs: https://docs.getmura.com/v7-1/installation-setup/installing-mura-codebase/