### PR TITLE
Additional changes required for ColdFusion 2018

### DIFF
--- a/requirements/mura/settings/settingsBean.cfc
+++ b/requirements/mura/settings/settingsBean.cfc
@@ -1344,8 +1344,14 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	<cfset var objectArgs={}>
 	<cfset var o="">
 	<cfset var objectfound=(arguments.conditional) ? false : true>
+	<cfset var tmpPath="">
 
-	<cfif directoryExists(expandPath(arguments.dir))>
+	<cfif reFindNoCase("^[a-zA-Z]:\\",arguments.dir)>
+		<cfset tmpPath=arguments.dir>
+	<cfelse>
+		<cfset tmpPath=expandPath(arguments.dir)>
+	</cfif>
+	<cfif directoryExists(tmpPath)>
 		<cfdirectory name="rs" directory="#expandPath(arguments.dir)#" action="list" type="dir">
 		<cfloop query="rs">
 


### PR DESCRIPTION
The `expandPath()` function is returning an unexpected string when the `arguments.dir` parameter contains an absolute path (instead of relative). When the parameter contains a string such as `C:\wwwroot\site\some-directory\` the `expandPath()` function is returning `C:\wwwroot\site\C:\wwwroot\site\some-directory\` which throws an error for the `directoryExists()` function.