### PR TITLE
renderMinJSFile and renderMinCSSFile

### DIFF
--- a/core/mura/content/contentRenderer.cfc
+++ b/core/mura/content/contentRenderer.cfc
@@ -3045,6 +3045,8 @@ Display Objects
 	<cfargument name="attrs" type="struct" default="#structNew()#">
 
 	<cfset var processedFilepath = this.getMinifiedFile(filepath=arguments.filepath, siteid=arguments.siteid) />
+	<cfset var attr = "" />
+	
 	<cfoutput>
 		<script src="#processedFilepath#" 
 			<cfloop collection="#arguments.attrs#" item=attr>
@@ -3060,6 +3062,8 @@ Display Objects
 	<cfargument name="siteid" default="">
 	<cfargument name="attrs" type="struct" default="#structNew()#">
 	<cfset var processedFilepath = this.getMinifiedFile(filepath=arguments.filepath, siteid=arguments.siteid) />
+	<cfset var attr = "" />
+
 	<cfoutput>
 		<link href="#processedFilepath#" 
 			<cfloop collection="#arguments.attrs#" item=attr>

--- a/core/mura/content/contentRenderer.cfc
+++ b/core/mura/content/contentRenderer.cfc
@@ -3039,6 +3039,41 @@ Display Objects
 	<cfreturn variables.contentRendererUtility.renderEditableAttribute(argumentCollection=arguments)>
 </cffunction>
 
+<cffunction name="renderMinifiedJs" output="true">
+	<cfargument name="filepath">
+
+	<cfset dir = GetDirectoryFromPath(arguments.filepath) />
+	<cfset filename = getFileFromPath(arguments.filepath) />
+	<cfset filenameArray = filename.listToArray(".") />
+	<cfset minifiedFilepath = dir & "dist/" & "#filenameArray[1]#.min.js" />
+	
+	<cfif !StructKeyExists(application, "jsFileLookup")>
+		<!--- Is the application scope the right place for this? --->
+		<cfset application.jsFileLookup = {}>
+	</cfif>
+
+	<cfset filepathArray = arguments.filepath.listToArray(".")/>
+
+	<cfoutput>
+		<!--- If key is in cache --->
+		<cfif structKeyExists(application.jsFileLookup,'#arguments.filepath#')>
+			<script src="#minifiedFilepath#"></script>
+		<!--- Else if minified file exists --->
+		<cfelseif fileExists(server.coldfusion.rootdir & minifiedFilepath)>
+			<!--- Add record to cache --->
+			<cfset application.jsFileLookup[arguments.filepath] = 1 />
+			<script src="#minifiedFilepath#"></script>
+		<!--- Else serve the unminified file --->
+		<cfelse>
+			<script src="#arguments.filepath#"></script>
+		</cfif>
+	</cfoutput>
+</cffunction>
+
+<!--- <cffunction name="renderMinifiedCss" output="true">
+
+</cffunction> --->
+
 <cffunction name="renderClassOption" output="false">
 	<cfargument name="object">
 	<cfargument name="objectid" default="">

--- a/core/mura/content/contentRenderer.cfc
+++ b/core/mura/content/contentRenderer.cfc
@@ -3042,7 +3042,7 @@ Display Objects
 <cffunction name="renderMinJSFile" output="true">
 	<cfargument name="filepath">
 	<cfargument name="siteid" default="">
-	<cfargument name="attrs">
+	<cfargument name="attrs" type="struct" default="#structNew()#">
 
 	<cfset var processedFilepath = this.getMinifiedFile(filepath=arguments.filepath, siteid=arguments.siteid) />
 	<cfoutput>
@@ -3058,6 +3058,7 @@ Display Objects
 <cffunction name="renderMinCSSFile" output="true">
 	<cfargument name="filepath">
 	<cfargument name="siteid" default="">
+	<cfargument name="attrs" type="struct" default="#structNew()#">
 	<cfset var processedFilepath = this.getMinifiedFile(filepath=arguments.filepath, siteid=arguments.siteid) />
 	<cfoutput>
 		<link href="#processedFilepath#" 

--- a/core/mura/content/contentRenderer.cfc
+++ b/core/mura/content/contentRenderer.cfc
@@ -3043,18 +3043,18 @@ Display Objects
 	<cfargument name="filepath">
 	<cfargument name="siteid" default="">
 
-	<cfset dir = GetDirectoryFromPath(arguments.filepath) />
-	<cfset filename = getFileFromPath(arguments.filepath) />
-	<cfset filenameArray = filename.listToArray(".") />
-	<cfset fileExtension = filenameArray[2] />
-	<cfset minifiedFilepath = dir & "dist/" & "#filenameArray[1]#.min.#fileExtension#" />
+	<cfset var dir = GetDirectoryFromPath(arguments.filepath) />
+	<cfset var filename = getFileFromPath(arguments.filepath) />
+	<cfset var filenameArray = filename.listToArray(".") />
+	<cfset var fileExtension = filenameArray[2] />
+	<cfset var minifiedFilepath = dir & "dist/" & "#filenameArray[1]#.min.#fileExtension#" />
 
-	<cfset site = application.settingsManager.getSite(arguments.siteid)/> 
-	<cfset cacheFactory = site.getCacheFactory(name="jsAndCssFileLookup")>
+	<cfset var site = application.settingsManager.getSite(arguments.siteid)/> 
+	<cfset var cacheFactory = site.getCacheFactory(name="jsAndCssFileLookup")>
 	
-	<cfset filepathArray = arguments.filepath.listToArray(".")/>
+	<cfset var filepathArray = arguments.filepath.listToArray(".")/>
 
-	<cfset processedFilepath = "" />
+	<cfset var processedFilepath = "" />
 	<!--- If key is in cache --->
 	<cfif cacheFactory.has(arguments.filepath)>
 		<cfset processedFilepath = cacheFactory.get(arguments.filepath) />

--- a/core/mura/content/contentRenderer.cfc
+++ b/core/mura/content/contentRenderer.cfc
@@ -3039,7 +3039,36 @@ Display Objects
 	<cfreturn variables.contentRendererUtility.renderEditableAttribute(argumentCollection=arguments)>
 </cffunction>
 
-<cffunction name="renderMinifiedJsOrCss" output="true">
+<cffunction name="renderMinJSFile" output="true">
+	<cfargument name="filepath">
+	<cfargument name="siteid" default="">
+	<cfargument name="attrs">
+
+	<cfset var processedFilepath = this.getMinifiedFile(filepath=arguments.filepath, siteid=arguments.siteid) />
+	<cfoutput>
+		<script src="#processedFilepath#" 
+			<cfloop collection="#arguments.attrs#" item=attr>
+				#attr#=#arguments.attrs[attr]#
+			</cfloop>
+		>
+		</script>
+	</cfoutput>
+</cffunction>
+
+<cffunction name="renderMinCSSFile" output="true">
+	<cfargument name="filepath">
+	<cfargument name="siteid" default="">
+	<cfset var processedFilepath = this.getMinifiedFile(filepath=arguments.filepath, siteid=arguments.siteid) />
+	<cfoutput>
+		<link href="#processedFilepath#" 
+			<cfloop collection="#arguments.attrs#" item=attr>
+				#attr#=#arguments.attrs[attr]#
+			</cfloop>
+		>
+	</cfoutput>
+</cffunction>
+
+<cffunction name="getMinifiedFile" output="true">
 	<cfargument name="filepath">
 	<cfargument name="siteid" default="">
 
@@ -3067,15 +3096,7 @@ Display Objects
 	<cfelse>
 		<cfset processedFilepath = arguments.filepath />
 	</cfif>
-
-	<cfoutput>
-		<cfif fileExtension EQ "js">
-			<script src="#processedFilepath#"></script>
-		<cfelseif fileExtension EQ "css">
-			<link rel="stylesheet" href="#processedFilepath#">
-		</cfif>
-	</cfoutput>
-
+	<cfreturn processedFilepath />
 </cffunction>
 
 <cffunction name="renderClassOption" output="false">


### PR DESCRIPTION
This PR creates two new functions in the contentRenderer: renderMinJSFile and renderMinCSSFile. Each accept a filename argument, and optionally a siteid argument and an "attrs" struct as an argument.

These functions return either a script element or a link element. They attempt to fetch the minified version of the file for the filepath argument. (There is an assumption that the minified version of the file will be in a directory called `dist` that is a sibling of the file.) If there is no minified file at that destination, the file at the original filepath is returned as the src/href attribute.