### PR TITLE
Closing paren in scaffolder moved outside of v-for

### DIFF
--- a/admin/core/views/carch/scaffold.cfm
+++ b/admin/core/views/carch/scaffold.cfm
@@ -90,7 +90,7 @@
 						<li><a @click="showAll" onclick="return false;" href="##"><i class="mi-cubes"></i>Custom Entities</a></li>
 						<li>
 							<strong><a href="##" onclick="return false;"><i class="mi-cube"></i>{{entityname}}
-								<span v-if="currentparent && currentparent.properties && Array.isArray(currentparent.properties._displaylist) && currentparent.properties._displaylist.length">(for {{currentparent.properties.entityname}}: <span v-for="item in currentparent.properties._displaylist">{{currentparent.properties[item.name]}})</span>
+								<span v-if="currentparent && currentparent.properties && Array.isArray(currentparent.properties._displaylist) && currentparent.properties._displaylist.length">(for {{currentparent.properties.entityname}}: <span v-for="item in currentparent.properties._displaylist">{{currentparent.properties[item.name]}}</span>)
 						</span>
 						</a></strong>
 						</li>


### PR DESCRIPTION
If there were multiple listview properties in the bean it would display multiple closing parens.