### PR TITLE
Setting Mura Config Variables via Java JVM Properties

### DIFF
--- a/core/appcfc/applicationSettings.cfm
+++ b/core/appcfc/applicationSettings.cfm
@@ -71,6 +71,7 @@ param name="request.muraPointInTime" default="";
 param name="request.muraTemplateMissing" default=false;
 param name="request.muraSysEnv" default="#createObject('java','java.lang.System').getenv()#";
 param name="request.muraSecrets" default={};
+param name="request.muraJVMProperties" default={};
 
 //https://www.bennadel.com/blog/2824-gethttprequestdata-may-break-your-request-in-coldfusion-but-gethttprequestdata-false-may-not.htm
 //Throws error in Lucee 5.2.4.37
@@ -110,6 +111,18 @@ if(!StructIsEmpty(request.muraSecrets)){
 }
 
 structDelete(request,'muraSecrets');
+
+request.muraJVMProperties = StructFilter(createObject('java','java.lang.System').getProperties(), function(key, value) {
+  return UCASE(LEFT(key, 5)) eq "MURA_";
+});
+if(!StructIsEmpty(request.muraJVMProperties)){
+	tempVars={};
+	structAppend(tempVars, request.muraSysEnv);
+	structAppend(tempVars, request.muraJVMProperties);
+	request.muraSysEnv = tempVars;
+}
+
+structDelete(request, 'muraJVMProperties');
 
 request.muraInDocker=len(getSystemEnvironmentSetting('MURA_DATASOURCE'));
 this.configPath=getDirectoryFromPath(getCurrentTemplatePath());


### PR DESCRIPTION
Currently in Mura, the method for setting/overriding Mura settings.ini config values via environment variables works great if the user is hosting Mura in a container or in a single-application-per-host environment.  

For users who are using a tool like CommandBox (outside of a container), loading in per-application environment variables via a .env file is currently a challenge, as the commandbox-dotenv module loads in the contents of an application's .env file into the JVM Properties, as the host's environment variables cannot be edited from the context in which CommandBox is running.

This change updates the `applicationSettings.cfm` code to see if there are any entries in the JVM properties collection that begin with "MURA_" and load them into the muraSysEnv structure so they can be used by Mura when loading the settings.ini config values.

While the Docker/container approach is a more elegant solution for multi-app hosts, unfortunately some companies aren't ready to transition to leveraging containers yet.  This solution provides a stepping stone for those organizations that are comfortable with the CommandBox ecosystem.