### PR TITLE
Fix for illegal argument exception being thrown after upgrading Java …

### DIFF
--- a/requirements/mura/javaloader/JavaProxy.cfc
+++ b/requirements/mura/javaloader/JavaProxy.cfc
@@ -64,7 +64,11 @@ Mark Mandel		27/08/2007		Created
 
 		constructor = _resolveMethodByParams("Constructor", _getClass().getConstructors(), arguments);
 
-		instance = constructor.newInstance(_buildArgumentArray(arguments));
+		if (StructCount(arguments) > 0){
+		   instance = constructor.newInstance(_buildArgumentArray(arguments));
+		} else {
+		   instance = constructor.newInstance(JavaCast("null", 0));
+		}
 
 		_setClassInstance(instance);
 


### PR DESCRIPTION
…to 8.241

This exact same fix had been introduced before back in 2016 but it is not included in the latest code.  Here is a link to that issue/fix: https://github.com/blueriver/MuraCMS/issues/2113#issuecomment-185779181

Not sure why it was removed.  You may need to research if this was causing other issues before merging.  I have not notice any other issues thus far.

Here is a snippet from the stacktrace that was being thrown:

java.lang.IllegalArgumentException at sun.reflect.GeneratedConstructorAccessor326.newInstance(Unknown Source) at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source) at java.lang.reflect.Constructor.newInstance(Unknown Source) at sun.reflect.GeneratedMethodAccessor193.invoke(Unknown Source) at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) at java.lang.reflect.Method.invoke(Unknown Source) at coldfusion.runtime.StructBean.invoke(StructBean.java:508) at coldfusion.runtime.CfJspPage._invoke(CfJspPage.java:2553) at cfJavaProxy2ecfc1292604940$funcINIT.runFunction(X:\webroot\requirements\mura\javaloader\JavaProxy.cfc:67) at coldfusion.runtime.UDFMethod.invoke(UDFMethod.java:487) at coldfusion.filter.SilentFilter.invoke(SilentFilter.java:47) at coldfusion.runtime.UDFMethod$ReturnTypeFilter.invoke(UDFMethod.java:420) at coldfusion.runtime.UDFMethod$ArgumentCollectionFilter.invoke(UDFMethod.java:383) at coldfusion.filter.FunctionAccessFilter.invoke(FunctionAccessFilter.java:95) at coldfusion.runtime.UDFMethod.runFilterChain(UDFMethod.java:334) at coldfusion.runtime.UDFMethod.invoke(UDFMethod.java:231) at coldfusion.runtime.TemplateProxy.invoke(TemplateProxy.java:643) at coldfusion.runtime.TemplateProxy.invoke(TemplateProxy.java:432) at coldfusion.runtime.TemplateProxy.invoke(TemplateProxy.java:402) at coldfusion.runtime.CfJspPage._invoke(CfJspPage.java:2483) at cfJavaLoader2ecfc649663110$funcLOADCLASSES.runFunction(X:\webroot\requirements\mura\javaloader\JavaLoader.cfc:261) at coldfusion.runtime.UDFMethod.invoke(UDFMethod.java:487) at coldfusion.filter.SilentFilter.invoke(SilentFilter.java:47) at 
...